### PR TITLE
Update code style according to the new configuration of prettier

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -2,5 +2,6 @@
   "printWidth": 120,
   "trailingComma": "all",
   "singleQuote": true,
-  "arrowParens": "always"
+  "arrowParens": "always",
+  "semi": false
 }

--- a/package.json
+++ b/package.json
@@ -16,7 +16,9 @@
     "build:lib": "lerna run build",
     "test": "lerna run test",
     "lint": "eslint 'packages/*/{src,__tests__}/**/*.ts'",
-    "prepare": "husky install"
+    "prepare": "husky install",
+    "format:check": "prettier -cu packages/**/src/*",
+    "format:write": "prettier -wu packages/**/src/*"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "5.44.0",
@@ -32,12 +34,9 @@
     "typescript": "4.9.3"
   },
   "lint-staged": {
-    "*.ts": [
-      "npx prettier --list-different",
+    "**/*": [
+      "prettier -wu",
       "npx eslint"
-    ],
-    "*.md": [
-      "prettier --list-different"
     ]
   }
 }

--- a/packages/cli/src/commands/node.ts
+++ b/packages/cli/src/commands/node.ts
@@ -1,13 +1,13 @@
-import { Command } from 'commander';
+import { Command } from 'commander'
 
 interface Args {
-  port: number;
+  port: number
 }
 
-const node = new Command('node');
-node.option('-p --port <number>', 'port number', '8114');
+const node = new Command('node')
+node.option('-p --port <number>', 'port number', '8114')
 node.action((args: Args) => {
-  console.log(`ckb running on: ${args.port}`);
-});
+  console.log(`ckb running on: ${args.port}`)
+})
 
-export { node };
+export { node }

--- a/packages/cli/src/main.ts
+++ b/packages/cli/src/main.ts
@@ -1,8 +1,8 @@
 #!/usr/bin/env node
-import { Command } from 'commander';
-import { node } from './commands/node';
+import { Command } from 'commander'
+import { node } from './commands/node'
 
-const program = new Command();
+const program = new Command()
 
-program.addCommand(node);
-program.parse();
+program.addCommand(node)
+program.parse()

--- a/packages/core/src/builtin-tasks/index.ts
+++ b/packages/core/src/builtin-tasks/index.ts
@@ -1,1 +1,1 @@
-import './mock';
+import './mock'

--- a/packages/core/src/builtin-tasks/mock.ts
+++ b/packages/core/src/builtin-tasks/mock.ts
@@ -1,8 +1,8 @@
-import { task } from '../config/config-env';
-import { paramTypes } from '../params';
+import { task } from '../config/config-env'
+import { paramTypes } from '../params'
 
 // for temporary, remove it when other built-in tasks are implemented.
 task('hello')
   .setDescription('say hello')
   .addParam('name', `what's your name`, 'alice', paramTypes.string, true)
-  .setAction(({ name }) => console.log(`hello ${name}`));
+  .setAction(({ name }) => console.log(`hello ${name}`))

--- a/packages/core/src/config/config-env.ts
+++ b/packages/core/src/config/config-env.ts
@@ -1,5 +1,5 @@
-import { ActionType, ConfigurableTaskDefinition, EnvironmentExtender, TaskArguments } from '../type';
-import { KuaiContext } from '../context';
+import { ActionType, ConfigurableTaskDefinition, EnvironmentExtender, TaskArguments } from '../type'
+import { KuaiContext } from '../context'
 
 /**
  * Creates a task, overriding any previous task with the same name.
@@ -15,7 +15,7 @@ export function task<ArgsT extends TaskArguments>(
   name: string,
   description?: string,
   action?: ActionType<ArgsT>,
-): ConfigurableTaskDefinition;
+): ConfigurableTaskDefinition
 
 /**
  * Creates a task without description, overriding any previous task
@@ -28,25 +28,25 @@ export function task<ArgsT extends TaskArguments>(
  *
  * @returns A task definition.
  */
-export function task<ArgsT extends TaskArguments>(name: string, action: ActionType<ArgsT>): ConfigurableTaskDefinition;
+export function task<ArgsT extends TaskArguments>(name: string, action: ActionType<ArgsT>): ConfigurableTaskDefinition
 
 export function task<ArgsT extends TaskArguments>(
   name: string,
   descriptionOrAction?: string | ActionType<ArgsT>,
   action?: ActionType<ArgsT>,
 ): ConfigurableTaskDefinition {
-  const ctx = KuaiContext.getInstance();
-  const loader = ctx.tasksLoader;
+  const ctx = KuaiContext.getInstance()
+  const loader = ctx.tasksLoader
 
   if (descriptionOrAction === undefined) {
-    return loader.task(name);
+    return loader.task(name)
   }
 
   if (typeof descriptionOrAction !== 'string') {
-    return loader.task(name, descriptionOrAction);
+    return loader.task(name, descriptionOrAction)
   }
 
-  return loader.task(name, descriptionOrAction, action);
+  return loader.task(name, descriptionOrAction, action)
 }
 
 /**
@@ -64,7 +64,7 @@ export function subtask<ArgsT extends TaskArguments>(
   name: string,
   description?: string,
   action?: ActionType<ArgsT>,
-): ConfigurableTaskDefinition;
+): ConfigurableTaskDefinition
 
 /**
  * Creates a subtask without description, overriding any previous
@@ -80,25 +80,25 @@ export function subtask<ArgsT extends TaskArguments>(
 export function subtask<ArgsT extends TaskArguments>(
   name: string,
   action: ActionType<ArgsT>,
-): ConfigurableTaskDefinition;
+): ConfigurableTaskDefinition
 
 export function subtask<ArgsT extends TaskArguments>(
   name: string,
   descriptionOrAction?: string | ActionType<ArgsT>,
   action?: ActionType<ArgsT>,
 ): ConfigurableTaskDefinition {
-  const ctx = KuaiContext.getInstance();
-  const loader = ctx.tasksLoader;
+  const ctx = KuaiContext.getInstance()
+  const loader = ctx.tasksLoader
 
   if (descriptionOrAction === undefined) {
-    return loader.subtask(name);
+    return loader.subtask(name)
   }
 
   if (typeof descriptionOrAction !== 'string') {
-    return loader.subtask(name, descriptionOrAction);
+    return loader.subtask(name, descriptionOrAction)
   }
 
-  return loader.subtask(name, descriptionOrAction, action);
+  return loader.subtask(name, descriptionOrAction, action)
 }
 
 /**
@@ -108,7 +108,7 @@ export function subtask<ArgsT extends TaskArguments>(
  * @param extender A function that receives the Runtime Environment.
  */
 export function extendEnvironment(extender: EnvironmentExtender): void {
-  const ctx = KuaiContext.getInstance();
-  const extenderManager = ctx.extendersManager;
-  extenderManager.add(extender);
+  const ctx = KuaiContext.getInstance()
+  const extenderManager = ctx.extendersManager
+  extenderManager.add(extender)
 }

--- a/packages/core/src/config/config-loading.ts
+++ b/packages/core/src/config/config-loading.ts
@@ -1,37 +1,37 @@
-import path from 'node:path';
-import { KuaiConfig, KuaiArguments } from '../type';
-import { getUserConfigPath } from '../project-structure';
-import { DEFAULT_KUAI_ARGUMENTS } from '../constants';
+import path from 'node:path'
+import { KuaiConfig, KuaiArguments } from '../type'
+import { getUserConfigPath } from '../project-structure'
+import { DEFAULT_KUAI_ARGUMENTS } from '../constants'
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function importCsjOrEsModule(filePath: string): any {
   // eslint-disable-next-line @typescript-eslint/no-var-requires
-  const imported = require(filePath);
-  return imported.default !== undefined ? imported.default : imported;
+  const imported = require(filePath)
+  return imported.default !== undefined ? imported.default : imported
 }
 
 export function resolveConfigPath(configPath: string | undefined): string | undefined {
   if (configPath === undefined) {
-    return getUserConfigPath();
+    return getUserConfigPath()
   }
 
   if (!path.isAbsolute(configPath)) {
-    configPath = path.join(process.cwd(), configPath);
-    configPath = path.normalize(configPath);
+    configPath = path.join(process.cwd(), configPath)
+    configPath = path.normalize(configPath)
   }
 
-  return configPath;
+  return configPath
 }
 
 export async function loadConfigAndTasks(args: KuaiArguments = {}): Promise<KuaiConfig> {
-  const configPath = resolveConfigPath(args.configPath);
+  const configPath = resolveConfigPath(args.configPath)
 
-  await import('../builtin-tasks');
+  await import('../builtin-tasks')
 
-  let userConfig;
+  let userConfig
 
   if (configPath) {
-    userConfig = importCsjOrEsModule(configPath);
+    userConfig = importCsjOrEsModule(configPath)
   }
 
   return {
@@ -41,5 +41,5 @@ export async function loadConfigAndTasks(args: KuaiArguments = {}): Promise<Kuai
       ...args,
       configPath,
     },
-  };
+  }
 }

--- a/packages/core/src/config/index.ts
+++ b/packages/core/src/config/index.ts
@@ -1,2 +1,2 @@
-export * from './config-env';
-export * from './config-loading';
+export * from './config-env'
+export * from './config-loading'

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -1,3 +1,3 @@
-import { KuaiArguments } from './type';
+import { KuaiArguments } from './type'
 
-export const DEFAULT_KUAI_ARGUMENTS: KuaiArguments = {};
+export const DEFAULT_KUAI_ARGUMENTS: KuaiArguments = {}

--- a/packages/core/src/context.ts
+++ b/packages/core/src/context.ts
@@ -1,41 +1,41 @@
-import { RuntimeEnvironment } from './type';
-import { TasksLoader } from './task-loader';
-import { ExtenderManager } from './extenders';
-import { KuaiError } from './errors';
-import { ERRORS } from './errors-list';
+import { RuntimeEnvironment } from './type'
+import { TasksLoader } from './task-loader'
+import { ExtenderManager } from './extenders'
+import { KuaiError } from './errors'
+import { ERRORS } from './errors-list'
 
 export class KuaiContext {
-  private static __KuaiContext?: KuaiContext;
+  private static __KuaiContext?: KuaiContext
 
   public static getInstance(): KuaiContext {
     if (this.__KuaiContext !== undefined) {
-      return this.__KuaiContext;
+      return this.__KuaiContext
     }
 
-    const ctx = new KuaiContext();
-    this.__KuaiContext = ctx;
-    return ctx;
+    const ctx = new KuaiContext()
+    this.__KuaiContext = ctx
+    return ctx
   }
 
   public deleteKuaiContext(): void {
-    KuaiContext.__KuaiContext = undefined;
+    KuaiContext.__KuaiContext = undefined
   }
 
-  public readonly tasksLoader = new TasksLoader();
-  public readonly extendersManager = new ExtenderManager();
-  public environment?: RuntimeEnvironment;
+  public readonly tasksLoader = new TasksLoader()
+  public readonly extendersManager = new ExtenderManager()
+  public environment?: RuntimeEnvironment
 
   public setRuntimeEnvironment(env: RuntimeEnvironment): void {
     if (this.environment !== undefined) {
-      throw new KuaiError(ERRORS.GENERAL.RUNTIME_ALREADY_DEFINED);
+      throw new KuaiError(ERRORS.GENERAL.RUNTIME_ALREADY_DEFINED)
     }
-    this.environment = env;
+    this.environment = env
   }
 
   public getRuntimeEnvironment(): RuntimeEnvironment {
     if (this.environment === undefined) {
-      throw new KuaiError(ERRORS.GENERAL.RUNTIME_NOT_DEFINED);
+      throw new KuaiError(ERRORS.GENERAL.RUNTIME_NOT_DEFINED)
     }
-    return this.environment;
+    return this.environment
   }
 }

--- a/packages/core/src/errors-list.ts
+++ b/packages/core/src/errors-list.ts
@@ -1,6 +1,6 @@
 export interface ErrorDescriptor {
-  code: string;
-  message: string;
+  code: string
+  message: string
 }
 
 export const ERRORS = {
@@ -58,4 +58,4 @@ Please run: npm install --save-dev ts-node`,
 Please run: npm install --save-dev typescript`,
     },
   },
-};
+}

--- a/packages/core/src/extenders.ts
+++ b/packages/core/src/extenders.ts
@@ -1,13 +1,13 @@
-import { EnvironmentExtender } from './type';
+import { EnvironmentExtender } from './type'
 
 export class ExtenderManager {
-  private readonly _extenders: EnvironmentExtender[] = [];
+  private readonly _extenders: EnvironmentExtender[] = []
 
   public add(extender: EnvironmentExtender): void {
-    this._extenders.push(extender);
+    this._extenders.push(extender)
   }
 
   public getExtenders(): EnvironmentExtender[] {
-    return this._extenders;
+    return this._extenders
   }
 }

--- a/packages/core/src/helper.ts
+++ b/packages/core/src/helper.ts
@@ -1,18 +1,18 @@
-import { loadTsNode } from './typescript-support';
-import { KuaiContext } from './context';
-import { KuaiRuntimeEnvironment } from './runtime';
-import { loadConfigAndTasks } from './config';
-import { KuaiArguments } from './type';
+import { loadTsNode } from './typescript-support'
+import { KuaiContext } from './context'
+import { KuaiRuntimeEnvironment } from './runtime'
+import { loadConfigAndTasks } from './config'
+import { KuaiArguments } from './type'
 
 export async function initialKuai(args: KuaiArguments = {}): Promise<KuaiContext> {
-  loadTsNode();
+  loadTsNode()
 
-  const ctx = KuaiContext.getInstance();
+  const ctx = KuaiContext.getInstance()
 
-  const config = await loadConfigAndTasks(args);
+  const config = await loadConfigAndTasks(args)
 
-  const env = new KuaiRuntimeEnvironment(config, ctx.tasksLoader.getTasks(), ctx.extendersManager.getExtenders());
-  ctx.setRuntimeEnvironment(env);
+  const env = new KuaiRuntimeEnvironment(config, ctx.tasksLoader.getTasks(), ctx.extendersManager.getExtenders())
+  ctx.setRuntimeEnvironment(env)
 
-  return ctx;
+  return ctx
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,9 +1,9 @@
-export { KuaiRuntimeEnvironment } from './runtime';
-export { paramTypes } from './params';
-export * from './type';
-export * from './errors';
-export * from './errors-list';
-export * from './config';
-export { KuaiContext } from './context';
-export * from './typescript-support';
-export * from './helper';
+export { KuaiRuntimeEnvironment } from './runtime'
+export { paramTypes } from './params'
+export * from './type'
+export * from './errors'
+export * from './errors-list'
+export * from './config'
+export { KuaiContext } from './context'
+export * from './typescript-support'
+export * from './helper'

--- a/packages/core/src/params.ts
+++ b/packages/core/src/params.ts
@@ -1,28 +1,28 @@
-import { ArgumentType } from './type';
+import { ArgumentType } from './type'
 
 const string: ArgumentType = {
   name: 'string',
   validate: (value) => typeof value === 'string',
-};
+}
 
 const boolean: ArgumentType = {
   name: 'boolean',
   validate: (value) => typeof value === 'boolean',
-};
+}
 
 const number: ArgumentType = {
   name: 'number',
   validate: (value) => typeof value === 'number',
-};
+}
 
 const path: ArgumentType = {
   name: 'path',
   validate: (value) => typeof value === 'string',
-};
+}
 
 export const paramTypes = {
   string,
   boolean,
   number,
   path,
-};
+}

--- a/packages/core/src/project-structure.ts
+++ b/packages/core/src/project-structure.ts
@@ -1,19 +1,19 @@
-import findUp from 'find-up';
+import findUp from 'find-up'
 
-const JS_CONFIG_FILENAME = 'kuai.config.js';
-const TS_CONFIG_FILENAME = 'kuai.config.ts';
+const JS_CONFIG_FILENAME = 'kuai.config.js'
+const TS_CONFIG_FILENAME = 'kuai.config.ts'
 
 export function isCwdInsideProject(): boolean {
-  return findUp.sync(TS_CONFIG_FILENAME) !== null || findUp.sync(JS_CONFIG_FILENAME) !== null;
+  return findUp.sync(TS_CONFIG_FILENAME) !== null || findUp.sync(JS_CONFIG_FILENAME) !== null
 }
 
 export function getUserConfigPath(): string | undefined {
-  const tsConfigPath = findUp.sync(TS_CONFIG_FILENAME);
+  const tsConfigPath = findUp.sync(TS_CONFIG_FILENAME)
   if (tsConfigPath) {
-    return tsConfigPath;
+    return tsConfigPath
   }
 
-  const pathToConfigFile = findUp.sync(JS_CONFIG_FILENAME);
+  const pathToConfigFile = findUp.sync(JS_CONFIG_FILENAME)
 
-  return pathToConfigFile;
+  return pathToConfigFile
 }

--- a/packages/core/src/task-loader.ts
+++ b/packages/core/src/task-loader.ts
@@ -1,11 +1,11 @@
-import { ActionType, TaskArguments, Task, TaskMap } from './type';
+import { ActionType, TaskArguments, Task, TaskMap } from './type'
 
-import { OverrideTask, SimpleTask } from './task';
+import { OverrideTask, SimpleTask } from './task'
 
 export class TasksLoader {
-  public readonly internalTask = this.subtask;
+  public readonly internalTask = this.subtask
 
-  private readonly _tasks: TaskMap = {};
+  private readonly _tasks: TaskMap = {}
 
   /**
    * Creates a task, overriding any previous task with the same name.
@@ -17,7 +17,7 @@ export class TasksLoader {
    * @param action The task's action.
    * @returns A task definition.
    */
-  public task<ArgsT extends TaskArguments>(name: string, description?: string, action?: ActionType<ArgsT>): Task;
+  public task<ArgsT extends TaskArguments>(name: string, description?: string, action?: ActionType<ArgsT>): Task
 
   /**
    * Creates a task without description, overriding any previous task
@@ -30,14 +30,14 @@ export class TasksLoader {
    *
    * @returns A task definition.
    */
-  public task<ArgsT extends TaskArguments>(name: string, action: ActionType<ArgsT>): Task;
+  public task<ArgsT extends TaskArguments>(name: string, action: ActionType<ArgsT>): Task
 
   public task<ArgsT extends TaskArguments>(
     name: string,
     descriptionOrAction?: string | ActionType<ArgsT>,
     action?: ActionType<ArgsT>,
   ): Task {
-    return this._addTask(name, descriptionOrAction, action, false);
+    return this._addTask(name, descriptionOrAction, action, false)
   }
 
   /**
@@ -51,7 +51,7 @@ export class TasksLoader {
    * @param action The task's action.
    * @returns A task definition.
    */
-  public subtask<ArgsT extends TaskArguments>(name: string, description?: string, action?: ActionType<ArgsT>): Task;
+  public subtask<ArgsT extends TaskArguments>(name: string, description?: string, action?: ActionType<ArgsT>): Task
 
   /**
    * Creates a subtask without description, overriding any previous
@@ -64,13 +64,13 @@ export class TasksLoader {
    * @param action The task's action.
    * @returns A task definition.
    */
-  public subtask<ArgsT extends TaskArguments>(name: string, action: ActionType<ArgsT>): Task;
+  public subtask<ArgsT extends TaskArguments>(name: string, action: ActionType<ArgsT>): Task
   public subtask<ArgsT extends TaskArguments>(
     name: string,
     descriptionOrAction?: string | ActionType<ArgsT>,
     action?: ActionType<ArgsT>,
   ): Task {
-    return this._addTask(name, descriptionOrAction, action, true);
+    return this._addTask(name, descriptionOrAction, action, true)
   }
 
   /**
@@ -79,7 +79,7 @@ export class TasksLoader {
    * @returns The tasks container.
    */
   public getTasks(): TaskMap {
-    return this._tasks;
+    return this._tasks
   }
 
   private _addTask<ArgT extends TaskArguments>(
@@ -88,25 +88,25 @@ export class TasksLoader {
     action?: ActionType<ArgT>,
     isSubtask?: boolean,
   ) {
-    const parentTask = this._tasks[name];
+    const parentTask = this._tasks[name]
 
     const task: Task =
-      parentTask !== undefined ? new OverrideTask(parentTask, isSubtask) : new SimpleTask(name, isSubtask);
+      parentTask !== undefined ? new OverrideTask(parentTask, isSubtask) : new SimpleTask(name, isSubtask)
 
     if (descriptionOrAction instanceof Function) {
-      action = descriptionOrAction;
-      descriptionOrAction = undefined;
+      action = descriptionOrAction
+      descriptionOrAction = undefined
     }
 
     if (descriptionOrAction !== undefined) {
-      task.setDescription(descriptionOrAction);
+      task.setDescription(descriptionOrAction)
     }
 
     if (action !== undefined) {
-      task.setAction(action);
+      task.setAction(action)
     }
 
-    this._tasks[name] = task;
-    return task;
+    this._tasks[name] = task
+    return task
   }
 }

--- a/packages/core/src/task.ts
+++ b/packages/core/src/task.ts
@@ -1,25 +1,25 @@
-import { Task, ActionType, TaskArguments, TaskParam, ArgumentType } from './type';
-import { paramTypes } from './params';
+import { Task, ActionType, TaskArguments, TaskParam, ArgumentType } from './type'
+import { paramTypes } from './params'
 
 export class SimpleTask implements Task {
-  public description?: string;
-  public action: ActionType<TaskArguments>;
-  readonly params: Record<string, TaskParam<TaskArguments>> = {};
+  public description?: string
+  public action: ActionType<TaskArguments>
+  readonly params: Record<string, TaskParam<TaskArguments>> = {}
 
   constructor(public readonly name: string, public readonly isSubtask: boolean = false) {
     this.action = () => {
-      throw new Error('Not implemented');
-    };
+      throw new Error('Not implemented')
+    }
   }
 
   public setDescription(description: string): this {
-    this.description = description;
-    return this;
+    this.description = description
+    return this
   }
 
   public setAction<ArgsT extends TaskArguments>(action: ActionType<ArgsT>): this {
-    this.action = action;
-    return this;
+    this.action = action
+    return this
   }
 
   public addParam<T>(
@@ -37,50 +37,50 @@ export class SimpleTask implements Task {
       description,
       isOptional,
       isFlag,
-    };
+    }
 
-    return this;
+    return this
   }
 }
 
 export class OverrideTask implements Task {
-  private _description?: string;
-  private _action?: ActionType<TaskArguments>;
+  private _description?: string
+  private _action?: ActionType<TaskArguments>
 
   constructor(public readonly parentTask: Task, public readonly isSubtask: boolean = false) {}
 
   public setDescription(description: string): this {
-    this._description = description;
-    return this;
+    this._description = description
+    return this
   }
 
   public setAction<ArgsT extends TaskArguments>(action: ActionType<ArgsT>): this {
-    this._action = action;
-    return this;
+    this._action = action
+    return this
   }
 
   public get name(): string {
-    return this.parentTask.name;
+    return this.parentTask.name
   }
 
   public get description(): string | undefined {
     if (this._description !== undefined) {
-      return this._description;
+      return this._description
     }
 
-    return this.parentTask.description;
+    return this.parentTask.description
   }
 
   public get action(): ActionType<TaskArguments> {
     if (this._action !== undefined) {
-      return this._action;
+      return this._action
     }
 
-    return this.parentTask.action;
+    return this.parentTask.action
   }
 
   public get params(): Record<string, TaskParam<TaskArguments>> {
-    return this.parentTask.params;
+    return this.parentTask.params
   }
 
   public addParam<T>(
@@ -91,10 +91,10 @@ export class OverrideTask implements Task {
     isOptional?: boolean,
   ): this {
     if (isOptional === undefined || !isOptional) {
-      throw new Error('Cannot add required params to an overridden task');
+      throw new Error('Cannot add required params to an overridden task')
     }
 
-    this.parentTask.addParam(name, description, defaultValue, type, true);
-    return this;
+    this.parentTask.addParam(name, description, defaultValue, type, true)
+    return this
   }
 }

--- a/packages/core/src/type/index.ts
+++ b/packages/core/src/type/index.ts
@@ -1,1 +1,1 @@
-export * from './runtime';
+export * from './runtime'

--- a/packages/core/src/type/runtime.ts
+++ b/packages/core/src/type/runtime.ts
@@ -1,38 +1,38 @@
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export type TaskArguments = any;
+export type TaskArguments = any
 
 export interface KuaiArguments {
-  configPath?: string;
+  configPath?: string
 }
 
 export type KuaiConfig = {
-  kuaiArguments?: KuaiArguments;
-};
+  kuaiArguments?: KuaiArguments
+}
 
-export type RunTaskFunction = (name: string, taskArguments?: TaskArguments) => Promise<unknown>;
+export type RunTaskFunction = (name: string, taskArguments?: TaskArguments) => Promise<unknown>
 
-export type EnvironmentExtender = (env: RuntimeEnvironment) => void;
+export type EnvironmentExtender = (env: RuntimeEnvironment) => void
 
 export interface RuntimeEnvironment {
-  readonly config: KuaiConfig;
-  readonly tasks: Record<string, Task>;
-  readonly run: RunTaskFunction;
+  readonly config: KuaiConfig
+  readonly tasks: Record<string, Task>
+  readonly run: RunTaskFunction
 }
 
 export interface RunSuperFunction<ArgT extends TaskArguments> {
-  (taskArguments?: ArgT): Promise<unknown>;
-  isDefined: boolean;
+  (taskArguments?: ArgT): Promise<unknown>
+  isDefined: boolean
 }
 
 export type ActionType<ArgsT extends TaskArguments> = (
   taskArgs: ArgsT,
   env: RuntimeEnvironment,
   runSuper: RunSuperFunction<ArgsT>,
-) => Awaited<unknown>;
+) => Awaited<unknown>
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export interface ArgumentType<T = any> {
-  name: string;
+  name: string
   /**
    * Check if argument value is of type <T>.
    *
@@ -40,12 +40,12 @@ export interface ArgumentType<T = any> {
    *
    * @throws HH301 if value is not of type <t>
    */
-  validate(argumentValue: T): void;
+  validate(argumentValue: T): void
 }
 
 export interface ConfigurableTaskDefinition<ArgsT extends TaskArguments = TaskArguments> {
-  setDescription(description: string): this;
-  setAction(action: ActionType<ArgsT>): this;
+  setDescription(description: string): this
+  setAction(action: ActionType<ArgsT>): this
 
   addParam<T>(
     name: string,
@@ -54,25 +54,25 @@ export interface ConfigurableTaskDefinition<ArgsT extends TaskArguments = TaskAr
     type?: ArgumentType<T>,
     isOptional?: boolean,
     isFlag?: boolean,
-  ): this;
+  ): this
 }
 export interface TaskParam<T = TaskArguments> {
-  name: string;
-  description?: string;
-  defaultValue?: T;
-  type: ArgumentType<T>;
-  isOptional: boolean;
-  isFlag: boolean;
+  name: string
+  description?: string
+  defaultValue?: T
+  type: ArgumentType<T>
+  isOptional: boolean
+  isFlag: boolean
 }
 
 export interface Task<ArgsT extends TaskArguments = TaskArguments> extends ConfigurableTaskDefinition<ArgsT> {
-  readonly name: string;
-  readonly description?: string;
-  readonly isSubtask: boolean;
-  readonly action: ActionType<ArgsT>;
+  readonly name: string
+  readonly description?: string
+  readonly isSubtask: boolean
+  readonly action: ActionType<ArgsT>
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  readonly params: Record<string, TaskParam<any>>;
+  readonly params: Record<string, TaskParam<any>>
 }
 
-export type TaskMap = Record<string, Task>;
+export type TaskMap = Record<string, Task>

--- a/packages/core/src/typescript-support.ts
+++ b/packages/core/src/typescript-support.ts
@@ -1,11 +1,11 @@
-import { resolveConfigPath } from './config/config-loading';
-import { KuaiError } from './errors';
-import { ERRORS } from './errors-list';
+import { resolveConfigPath } from './config/config-loading'
+import { KuaiError } from './errors'
+import { ERRORS } from './errors-list'
 
-let cachedIsTypescriptSupported: boolean | undefined;
+let cachedIsTypescriptSupported: boolean | undefined
 
 export function isRunningKuaiCoreTests(): boolean {
-  return __filename.endsWith('.ts');
+  return __filename.endsWith('.ts')
 }
 
 /**
@@ -13,60 +13,60 @@ export function isRunningKuaiCoreTests(): boolean {
  * @param configPath The config path if provider by the user.
  */
 export function willRunWithTypescript(configPath?: string): boolean {
-  const config = resolveConfigPath(configPath);
-  return config ? isTypescriptFile(config) : false;
+  const config = resolveConfigPath(configPath)
+  return config ? isTypescriptFile(config) : false
 }
 
 export function isTypescriptSupported(): boolean {
   if (cachedIsTypescriptSupported === undefined) {
     try {
-      require.resolve('typescript');
-      require.resolve('ts-node');
-      cachedIsTypescriptSupported = true;
+      require.resolve('typescript')
+      require.resolve('ts-node')
+      cachedIsTypescriptSupported = true
     } catch {
-      cachedIsTypescriptSupported = false;
+      cachedIsTypescriptSupported = false
     }
   }
 
-  return cachedIsTypescriptSupported;
+  return cachedIsTypescriptSupported
 }
 
 export function loadTsNode(tsConfigPath?: string, shouldTypecheck = false): void {
   try {
-    require.resolve('typescript');
+    require.resolve('typescript')
   } catch {
-    throw new KuaiError(ERRORS.GENERAL.TYPESCRIPT_NOT_INSTALLED);
+    throw new KuaiError(ERRORS.GENERAL.TYPESCRIPT_NOT_INSTALLED)
   }
 
   try {
-    require.resolve('ts-node');
+    require.resolve('ts-node')
   } catch {
-    throw new KuaiError(ERRORS.GENERAL.TS_NODE_NOT_INSTALLED);
+    throw new KuaiError(ERRORS.GENERAL.TS_NODE_NOT_INSTALLED)
   }
 
   // If we are running tests we just want to transpile
   if (isRunningKuaiCoreTests()) {
-    require('ts-node/register/transpile-only');
-    return;
+    require('ts-node/register/transpile-only')
+    return
   }
 
   if (tsConfigPath !== undefined) {
-    process.env.TS_NODE_PROJECT = tsConfigPath;
+    process.env.TS_NODE_PROJECT = tsConfigPath
   }
 
   if (process.env.TS_NODE_FILES === undefined) {
-    process.env.TS_NODE_FILES = 'true';
+    process.env.TS_NODE_FILES = 'true'
   }
 
-  let tsNodeRequirement = 'ts-node/register';
+  let tsNodeRequirement = 'ts-node/register'
 
   if (!shouldTypecheck) {
-    tsNodeRequirement += '/transpile-only';
+    tsNodeRequirement += '/transpile-only'
   }
 
-  require(tsNodeRequirement);
+  require(tsNodeRequirement)
 }
 
 function isTypescriptFile(path: string): boolean {
-  return path.endsWith('.ts');
+  return path.endsWith('.ts')
 }


### PR DESCRIPTION
This PR updates the configuration of prettier to disable semicolons and update the pre-commit hook to run the `format` script instead of checking the code format.

The new style is also adopted in this PR so all unnecessary semicolons are removed.

Ref: https://github.com/ckb-js/kuai/issues/40