### PR TITLE
feat: implement the registry with a container

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6139,6 +6139,11 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/inversify": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/inversify/-/inversify-6.0.1.tgz",
+      "integrity": "sha512-B3ex30927698TJENHR++8FfEaJGqoWOgI6ZY5Ht/nLUsFCwHn6akbwtnUAPCgUepAnTpe2qHxhDNjoKLyz6rgQ=="
+    },
     "node_modules/ip": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ip/-/ip-2.0.0.tgz",
@@ -11590,6 +11595,7 @@
       "version": "0.0.1",
       "license": "MIT",
       "dependencies": {
+        "inversify": "6.0.1",
         "reflect-metadata": "0.1.13",
         "tslib": "2.4.1"
       },
@@ -12559,6 +12565,7 @@
       "version": "file:packages/models",
       "requires": {
         "@jest/globals": "29.3.1",
+        "inversify": "6.0.1",
         "reflect-metadata": "0.1.13",
         "tslib": "2.4.1",
         "typescript": "4.8.4"
@@ -16415,6 +16422,11 @@
         "through": "^2.3.6",
         "wrap-ansi": "^7.0.0"
       }
+    },
+    "inversify": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/inversify/-/inversify-6.0.1.tgz",
+      "integrity": "sha512-B3ex30927698TJENHR++8FfEaJGqoWOgI6ZY5Ht/nLUsFCwHn6akbwtnUAPCgUepAnTpe2qHxhDNjoKLyz6rgQ=="
     },
     "ip": {
       "version": "2.0.0",

--- a/packages/models/__tests__/actor/actor-reference.ts
+++ b/packages/models/__tests__/actor/actor-reference.ts
@@ -11,7 +11,7 @@ describe(`Test Actor Reference`, () => {
     }
     const ref = new ActorReference(REF.name, REF.path, REF.protocol)
 
-    it(`should have natm`, () => {
+    it(`should have name`, () => {
       expect(ref.name).toBe(REF.name)
     })
 

--- a/packages/models/__tests__/actor/actor-reference.ts
+++ b/packages/models/__tests__/actor/actor-reference.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from '@jest/globals'
+import { ActorReference, InvalidPathException } from '../../src'
+
+describe(`Test Actor Reference`, () => {
+  describe(`should have specific attributes`, () => {
+    const REF = {
+      name: 'test_name',
+      path: '/test_path/',
+      protocol: 'http',
+      uri: `http://test_path/test_name`,
+    }
+    const ref = new ActorReference(REF.name, REF.path, REF.protocol)
+
+    it(`should have natm`, () => {
+      expect(ref.name).toBe(REF.name)
+    })
+
+    it(`should have path`, () => {
+      expect(ref.path).toBe(REF.path)
+    })
+
+    it(`should have protocol`, () => {
+      expect(ref.protocol).toBe(REF.protocol)
+    })
+
+    it(`should have uri`, () => {
+      expect(ref.uri).toBe(REF.uri)
+    })
+
+    it(`should have json`, () => {
+      expect(ref.json).toMatchObject(REF)
+    })
+  })
+
+  describe(`should have default attributes`, () => {
+    const ref = new ActorReference('test_name')
+
+    it(`should have default path "/"`, () => {
+      expect(ref.path).toBe('/')
+    })
+
+    it(`should have default protocol "local"`, () => {
+      expect(ref.protocol).toBe('local')
+    })
+  })
+
+  describe(`should be formatted in string`, () => {
+    const ref = new ActorReference('test_name')
+
+    it(`should be formatted in string`, () => {
+      expect(`${ref}`).toBe(`local://test_name`)
+    })
+  })
+
+  describe(`should throw exceptions if ref is invalid`, () => {
+    describe(`should throw an exception if path is invalid`, () => {
+      it(`should throw an exception if path does not start wtih /`, () => {
+        try {
+          new ActorReference('test_name', 'test_path/')
+        } catch (e) {
+          expect(e).toBeInstanceOf(InvalidPathException)
+        }
+      })
+
+      it(`should throw an exception if path does not end wtih /`, () => {
+        try {
+          new ActorReference('test_name', '/test_path')
+        } catch (e) {
+          expect(e).toBeInstanceOf(InvalidPathException)
+        }
+      })
+    })
+  })
+})

--- a/packages/models/__tests__/actor/actor.ts
+++ b/packages/models/__tests__/actor/actor.ts
@@ -1,87 +1,91 @@
-import { jest, describe, it, expect, beforeAll, afterAll, afterEach } from '@jest/globals';
-import { ActorBase, MessageQueue, Registry } from '../../src/actor';
-import { Behavior } from '../../src/utils';
+import { jest, describe, it, expect, beforeAll, afterAll, afterEach } from '@jest/globals'
+import { ActorBase, MessageQueue, Registry, Behavior, ProviderKey } from '../../src'
+
+const PARENT_REF = {
+  name: `parent`,
+  path: `/`,
+  protocol: `local`,
+  uri: `local://parent`,
+}
+
+const CHILD_REF = {
+  name: `child`,
+  path: `/parent/`,
+  protocol: `local`,
+  uri: `local://parent/child`,
+}
+class ParentActor extends ActorBase {}
+class ChildActor extends ActorBase {}
+
+Reflect.defineMetadata(ProviderKey.Actor, { ref: PARENT_REF }, ParentActor)
+Reflect.defineMetadata(ProviderKey.Actor, { ref: CHILD_REF }, ChildActor)
 
 describe(`Test Actor`, () => {
-  const registry = new Registry(ActorBase);
-  const mqPush = jest.fn();
+  const registry = new Registry()
+  const mqPush = jest.fn()
   class MQ extends MessageQueue {
-    push = mqPush;
+    push = mqPush
   }
 
-  const PARENT_REF = {
-    name: `parent`,
-    path: `/`,
-    protocol: `local`,
-    uri: `local://parent`,
-  };
-
-  const CHILD_REF = {
-    name: `child`,
-    path: `/parent`,
-    protocol: `local`,
-    uri: `local://parent/child`,
-  };
-
   beforeAll(() => {
-    globalThis.mq = new MQ(registry);
-  });
+    globalThis.mq = new MQ(registry)
+  })
 
   afterAll(() => {
-    delete globalThis.mq;
-  });
+    delete globalThis.mq
+  })
 
   afterEach(() => {
-    mqPush.mockClear();
-  });
+    mqPush.mockClear()
+  })
 
   describe(`should have ref`, () => {
     it(`should be a parent path if parent is nil`, () => {
-      const actor = new ActorBase(undefined, PARENT_REF.name);
-      expect(actor.ref).toMatchObject(PARENT_REF);
-    });
+      const actor = new ParentActor()
+      expect(actor.ref).toMatchObject(PARENT_REF)
+    })
 
     it(`should be a child path if parent is non-nil`, () => {
-      const actor = new ActorBase(PARENT_REF, CHILD_REF.name);
-      expect(actor.ref).toMatchObject(CHILD_REF);
-    });
-  });
+      const actor = new ChildActor()
+      expect(actor.ref).toMatchObject(CHILD_REF)
+    })
+  })
 
   describe(`should push a message to message queue when static call/cast is invoked`, () => {
-    const payload = { symbol: Symbol(`test`) };
+    const payload = { symbol: Symbol(`test`) }
 
     it(`should push a message when static call is invoked`, () => {
-      ActorBase.call(CHILD_REF.uri, PARENT_REF, payload);
-      expect(mqPush).toBeCalledWith(CHILD_REF.uri, { from: PARENT_REF, behavior: Behavior.Call, payload });
-    });
+      ActorBase.call(CHILD_REF.uri, PARENT_REF, payload)
+      expect(mqPush).toBeCalledWith(CHILD_REF.uri, { from: PARENT_REF, behavior: Behavior.Call, payload })
+    })
 
     it(`should push a message when static cast is invoked`, () => {
-      ActorBase.cast(CHILD_REF.uri, PARENT_REF, payload);
-      expect(mqPush).toBeCalledWith(CHILD_REF.uri, { from: PARENT_REF, behavior: Behavior.Cast, payload });
-    });
-  });
+      ActorBase.cast(CHILD_REF.uri, PARENT_REF, payload)
+      expect(mqPush).toBeCalledWith(CHILD_REF.uri, { from: PARENT_REF, behavior: Behavior.Cast, payload })
+    })
+  })
 
   describe(`should push a message to message queue when instance method call/cast is invoked`, () => {
-    const payload = { symbol: Symbol(`test`) };
+    const payload = { symbol: Symbol(`test`) }
 
     it(`should push a message when instance method call is invoked`, () => {
-      const actor = new ActorBase(undefined, PARENT_REF.name);
-      actor.call(CHILD_REF.uri, payload);
+      const actor = new ParentActor()
+      actor.call(CHILD_REF.uri, payload)
       expect(mqPush).toBeCalledWith(CHILD_REF.uri, {
         from: PARENT_REF,
         behavior: Behavior.Call,
         payload,
-      });
-    });
+      })
+    })
 
     it(`should push a message when instance method cast is invoked`, () => {
-      const actor = new ActorBase(undefined, PARENT_REF.name);
-      actor.cast(CHILD_REF.uri, payload);
+      const actor = new ParentActor()
+      actor.cast(CHILD_REF.uri, payload)
       expect(mqPush).toBeCalledWith(CHILD_REF.uri, {
         from: PARENT_REF,
         behavior: Behavior.Cast,
         payload,
-      });
-    });
-  });
-});
+      })
+    })
+  })
+})

--- a/packages/models/__tests__/actor/registry/index.ts
+++ b/packages/models/__tests__/actor/registry/index.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it, beforeEach } from '@jest/globals'
+
+import {
+  Registry,
+  ActorBase,
+  ProviderKey,
+  ActorReference,
+  DuplicatedActorException,
+  InvalidActorURIException,
+} from '../../../src'
+
+class ChildActor extends ActorBase {}
+class ParentActor extends ActorBase {}
+
+Reflect.defineMetadata(ProviderKey.Actor, { ref: new ActorReference('child', '/parent/') }, ChildActor)
+Reflect.defineMetadata(ProviderKey.Actor, { ref: new ActorReference('parent') }, ParentActor)
+
+describe(`Test Registry`, () => {
+  let registry: Registry
+
+  beforeEach(() => {
+    registry = new Registry()
+    registry.bind(ParentActor)
+    registry.bind(ChildActor)
+  })
+
+  describe.skip(`should have method Registry#load`, () => {
+    // TODO:
+  })
+
+  describe(`should have method Registry#list`, () => {
+    it(`should list 2 uris`, () => {
+      expect([...registry.list()]).toEqual(['local://parent', 'local://parent/child'])
+    })
+  })
+
+  describe(`should have method Registry#find`, () => {
+    it(`should return an actor instance if found`, () => {
+      expect(registry.find(`local://parent/child`)).toBeInstanceOf(ActorBase)
+    })
+
+    it(`should return undefined if not found`, () => {
+      expect(registry.find(`local://root`)).toBeUndefined()
+    })
+  })
+
+  describe(`should have method Registry#isLive`, () => {
+    it(`should return true if the specific actor is bound`, () => {
+      expect(registry.isLive(`local://parent/child`)).toBeTruthy()
+    })
+
+    it(`should return true if the specific actor is not bound`, () => {
+      expect(registry.find(`local://root`)).toBeFalsy()
+    })
+  })
+
+  describe(`should have method bind`, () => {
+    it(`should throw an exception if bind repeatedly`, () => {
+      try {
+        registry.bind(ParentActor)
+      } catch (e) {
+        expect(e).toBeInstanceOf(DuplicatedActorException)
+      }
+    })
+
+    it(`should throw an exception if uri is empty`, () => {
+      try {
+        class InvalidActor extends ActorBase {}
+        Reflect.defineMetadata(ProviderKey.Actor, { ref: { uri: '' } }, InvalidActor)
+        registry.bind(InvalidActor)
+      } catch (e) {
+        expect(e).toBeInstanceOf(InvalidActorURIException)
+      }
+    })
+  })
+})

--- a/packages/models/__tests__/utils/decorator/provider.ts
+++ b/packages/models/__tests__/utils/decorator/provider.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from '@jest/globals'
+import { ActorProvider, ActorProviderException, ProviderKey } from '../../../src'
+
+// TODO: add tests of default ref metdata after uuid is used
+
+describe(`Test providers`, () => {
+  describe(`Test ActorProvider`, () => {
+    it(`should throw an exception if target is undefined`, () => {
+      try {
+        ActorProvider({})(undefined)
+      } catch (e) {
+        expect(e).toBeInstanceOf(ActorProviderException)
+      }
+    })
+
+    it(`should throw an exception if target is not a function`, () => {
+      try {
+        ActorProvider({})('1')
+      } catch (e) {
+        expect(e).toBeInstanceOf(ActorProviderException)
+      }
+    })
+
+    it(`should add metadata of actor ref`, () => {
+      const target = () => {
+        // ignore
+      }
+      ActorProvider({ name: 'test_name' })(target)
+      const metadata = Reflect.getMetadata(ProviderKey.Actor, target)
+      expect(metadata.ref).toMatchObject({
+        name: 'test_name',
+        path: '/',
+        protocol: 'local',
+        uri: 'local://test_name',
+      })
+    })
+  })
+})

--- a/packages/models/package.json
+++ b/packages/models/package.json
@@ -29,6 +29,7 @@
     "url": "https://github.com/ckb-js/kuai/issues"
   },
   "dependencies": {
+    "inversify": "6.0.1",
     "reflect-metadata": "0.1.13",
     "tslib": "2.4.1"
   },

--- a/packages/models/src/actor/actor-reference.ts
+++ b/packages/models/src/actor/actor-reference.ts
@@ -1,0 +1,51 @@
+import type { ActorRef, ActorName, ActorURI } from './interface'
+import { InvalidPathException, PROTOCOL } from '../utils'
+
+export class ActorReference {
+  #name: ActorName
+  #path: string
+  #protocol: string
+  #uri: ActorURI
+
+  get name(): ActorName {
+    return this.#name
+  }
+
+  get path(): string {
+    return this.#path
+  }
+
+  get protocol(): string {
+    return this.#protocol
+  }
+
+  get uri(): ActorURI {
+    return this.#uri
+  }
+
+  get json(): ActorRef {
+    return {
+      name: this.name,
+      path: this.path,
+      protocol: this.protocol,
+      uri: this.uri,
+    }
+  }
+
+  constructor(name: symbol | string, path = '/', protocol: string = PROTOCOL.LOCAL) {
+    // TODO: add more validation
+    this.#name = name
+    this.#protocol = protocol
+    this.#path = path
+
+    if (this.#path !== '/' && !/^\/\w+\/$/.test(this.#path)) {
+      throw new InvalidPathException(this.#path)
+    }
+
+    this.#uri = this.#protocol + ':/' + this.#path + this.#name.toString()
+  }
+
+  toString(): string {
+    return this.uri
+  }
+}

--- a/packages/models/src/actor/index.ts
+++ b/packages/models/src/actor/index.ts
@@ -2,6 +2,7 @@
  * @tutorial https://github.com/ckb-js/kuai/issues/4
  */
 export * from './actor'
+export * from './actor-reference'
 export * from './interface'
 export * from './message-queue'
 export * from './registry'

--- a/packages/models/src/actor/interface.ts
+++ b/packages/models/src/actor/interface.ts
@@ -1,10 +1,10 @@
 import { Behavior } from '../utils'
 
+export type ActorName = string | symbol
 export type ActorURI = string
 
-// TODO:
 export interface ActorRef {
-  name: symbol | string
+  name: ActorName
   protocol: string
   path: string
   uri: ActorURI

--- a/packages/models/src/examples/dapp/actors/base.ts
+++ b/packages/models/src/examples/dapp/actors/base.ts
@@ -1,6 +1,6 @@
-import { Actor, MessageQueue, Registry, ActorMessage, MessagePayload } from '../actor'
+import { Actor, ActorMessage, MessagePayload } from '../../../'
 
-const Step: Record<string, symbol> = {
+export const Step: Record<string, symbol> = {
   One: Symbol('one'),
   Two: Symbol('two'),
   Done: Symbol('done'),
@@ -9,7 +9,10 @@ const Step: Record<string, symbol> = {
 /**
  * add business logic in an actor
  */
-class CustomActor<State extends { value: number }, Message extends MessagePayload> extends Actor<State, Message> {
+export class CustomActorBase<
+  State extends { value: number } = { value: number },
+  Message extends MessagePayload = MessagePayload,
+> extends Actor<State, Message> {
   #value = 0
 
   handleCall = (msg: ActorMessage<Message>): void => {
@@ -78,19 +81,3 @@ class CustomActor<State extends { value: number }, Message extends MessagePayloa
     return state
   }
 }
-
-/**
- * initialize the registry, should be done by the framework
- */
-const registry = new Registry(CustomActor)
-
-/**
- * initialize the message queue, should be done by the framekwork
- */
-globalThis.mq = new MessageQueue(registry)
-globalThis.mq.start()
-
-const rootRef = registry.spawn({ name: 'root' })
-const childOneRef = registry.spawn({ parent: rootRef, name: 'child_one' })
-
-Actor.call(childOneRef.uri, rootRef, { symbol: Step.One })

--- a/packages/models/src/examples/dapp/actors/child.ts
+++ b/packages/models/src/examples/dapp/actors/child.ts
@@ -2,4 +2,4 @@ import { ActorProvider } from '../../../'
 import { CustomActorBase } from './base'
 
 @ActorProvider({ name: 'child', path: '/parent/' })
-export class ParentActor extends CustomActorBase {}
+export class ChildActor extends CustomActorBase {}

--- a/packages/models/src/examples/dapp/actors/child.ts
+++ b/packages/models/src/examples/dapp/actors/child.ts
@@ -1,0 +1,5 @@
+import { ActorProvider } from '../../../'
+import { CustomActorBase } from './base'
+
+@ActorProvider({ name: 'child', path: '/parent/' })
+export class ParentActor extends CustomActorBase {}

--- a/packages/models/src/examples/dapp/actors/parent.ts
+++ b/packages/models/src/examples/dapp/actors/parent.ts
@@ -1,0 +1,5 @@
+import { ActorProvider } from '../../../'
+import { CustomActorBase } from './base'
+
+@ActorProvider({ name: 'parent' })
+export class ParentActor extends CustomActorBase {}

--- a/packages/models/src/examples/dapp/index.ts
+++ b/packages/models/src/examples/dapp/index.ts
@@ -1,0 +1,30 @@
+import { cwd } from 'node:process'
+import { resolve } from 'node:path'
+import { Actor, MessageQueue, Registry } from '../../'
+import { Step } from './actors/base'
+
+declare global {
+  /* eslint-disable-next-line no-var */
+  var mq: MessageQueue | undefined
+}
+
+/**
+ * initialize the registry, should be done by the framework
+ */
+const registry = new Registry()
+registry.load(resolve(cwd(), 'src', 'examples', 'dapp'))
+
+/**
+ * initialize the message queue, should be done by the framekwork
+ */
+globalThis.mq = new MessageQueue(registry)
+globalThis.mq.start()
+
+const parent = registry.find('local://parent')
+const child = registry.find('local://parent/child')
+
+if (!parent || !child) {
+  throw new Error()
+}
+
+Actor.call(child.ref.uri, parent.ref, { symbol: Step.One })

--- a/packages/models/src/index.ts
+++ b/packages/models/src/index.ts
@@ -1,1 +1,3 @@
 import 'reflect-metadata'
+export * from './actor'
+export * from './utils'

--- a/packages/models/src/utils/decorator/index.ts
+++ b/packages/models/src/utils/decorator/index.ts
@@ -1,0 +1,1 @@
+export * from './provider'

--- a/packages/models/src/utils/decorator/provider.ts
+++ b/packages/models/src/utils/decorator/provider.ts
@@ -1,0 +1,23 @@
+import type { ActorRef } from '../../actor'
+import { ActorReference } from '../../actor'
+import { ActorProviderException } from '../exception'
+
+export const ProviderKey = {
+  Actor: Symbol('container:actor'),
+}
+
+export const ActorProvider = (actorRef: Partial<Pick<ActorRef, 'name' | 'path'>> = {}) => {
+  return (target: unknown): void => {
+    if (!target || typeof target !== 'function') {
+      throw new ActorProviderException()
+    }
+
+    Reflect.defineMetadata(
+      ProviderKey.Actor,
+      {
+        ref: new ActorReference(actorRef.name || Date.now().toString(), actorRef.path || '/').json, // TODO: use uuid in actor name
+      },
+      target,
+    )
+  }
+}

--- a/packages/models/src/utils/exception.ts
+++ b/packages/models/src/utils/exception.ts
@@ -1,0 +1,28 @@
+export class InvalidPathException extends Error {
+  constructor(path: string) {
+    super(`${path} is invalid`)
+  }
+}
+export class InvalidActorURIException extends Error {
+  constructor(uri: unknown) {
+    super(`uri ${uri} is invalid`)
+  }
+}
+
+export class DuplicatedActorException extends Error {
+  constructor(uri: string) {
+    super(`actor ${uri} has been bound`)
+  }
+}
+
+export class MessageQueueNotFoundException extends Error {
+  constructor() {
+    super(`message queue is not found`)
+  }
+}
+
+export class ActorProviderException extends Error {
+  constructor() {
+    super(`ActorProvider is expected to be used with an Actor class`)
+  }
+}

--- a/packages/models/src/utils/index.ts
+++ b/packages/models/src/utils/index.ts
@@ -1,1 +1,3 @@
 export * from './constant'
+export * from './decorator'
+export * from './exception'

--- a/packages/models/tsconfig.json
+++ b/packages/models/tsconfig.json
@@ -17,5 +17,5 @@
     "skipLibCheck": true,
     "declaration": true
   },
-  "exclude": ["__tests__"]
+  "exclude": ["lib", "__tests__"]
 }


### PR DESCRIPTION
This PR implements the registry of actor models with a container
which scans modules on initiation to bind user-defined actor classes
into the container and instantiate them on demand

Once the project starts, the registry will scan all files and bind classes
decorated by `ActorProvider` into the container and instantiate them 
lazily by calling `registry.find(uri)`

Ref: https://github.com/ckb-js/kuai/issues/39