### PR TITLE
feat(io): export the modules in @kuai/io

### DIFF
--- a/packages/io/package.json
+++ b/packages/io/package.json
@@ -4,7 +4,9 @@
   "description": "kuai io layer",
   "homepage": "https://github.com/ckb-js/kuai#readme",
   "license": "MIT",
-  "main": "lib/index.js",
+  "exports": {
+    ".": "./lib/index.js"
+  },
   "directories": {
     "lib": "lib",
     "test": "__tests__"

--- a/packages/io/package.json
+++ b/packages/io/package.json
@@ -4,7 +4,7 @@
   "description": "kuai io layer",
   "homepage": "https://github.com/ckb-js/kuai#readme",
   "license": "MIT",
-  "main": "lib/io.js",
+  "main": "lib/index.js",
   "directories": {
     "lib": "lib",
     "test": "__tests__"

--- a/packages/io/src/index.ts
+++ b/packages/io/src/index.ts
@@ -1,0 +1,5 @@
+export * from './listener'
+export * as types from './types'
+export * from './adapter'
+export * from './cor'
+export * from './router'


### PR DESCRIPTION
I think the listener in `@kuai/io` should be exported, then the `resource binding` in issue #85 could use it.