### PR TITLE
fix: mock ioredis in tests of models

### DIFF
--- a/packages/models/__tests__/store/store.ts
+++ b/packages/models/__tests__/store/store.ts
@@ -3,6 +3,15 @@ import { NonExistentException, NonStorageInstanceException } from '../../src/exc
 import { ChainStorage, JSONStore, Store, Behavior, ProviderKey, StorageLocation, StorageSchema } from '../../src'
 import BigNumber from 'bignumber.js'
 
+const mockXAdd = jest.fn()
+const mockXRead = jest.fn<() => void>()
+jest.mock('ioredis', () => {
+  return class Redis {
+    xread = mockXRead
+    xadd = mockXAdd
+  }
+})
+
 const ref = {
   name: '',
   protocol: '',


### PR DESCRIPTION
CI blames that the max retries per request limit was reached because redis is not running in github action so the ioredis keeps retrying.

This commit mocks the ioredis in tests of models so it won't emit requests actually.