### PR TITLE
feat: update npm scope to '@ckb-js'

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -643,6 +643,30 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true
     },
+    "node_modules/@ckb-js/kuai-cli": {
+      "resolved": "packages/cli",
+      "link": true
+    },
+    "node_modules/@ckb-js/kuai-core": {
+      "resolved": "packages/core",
+      "link": true
+    },
+    "node_modules/@ckb-js/kuai-docker-node": {
+      "resolved": "packages/docker-node",
+      "link": true
+    },
+    "node_modules/@ckb-js/kuai-io": {
+      "resolved": "packages/io",
+      "link": true
+    },
+    "node_modules/@ckb-js/kuai-models": {
+      "resolved": "packages/models",
+      "link": true
+    },
+    "node_modules/@ckb-js/kuai-typeorm": {
+      "resolved": "packages/typeorm",
+      "link": true
+    },
     "node_modules/@ckb-lumos/base": {
       "version": "0.19.0",
       "resolved": "https://registry.npmjs.org/@ckb-lumos/base/-/base-0.19.0.tgz",
@@ -1261,30 +1285,6 @@
         "@jridgewell/resolve-uri": "3.1.0",
         "@jridgewell/sourcemap-codec": "1.4.14"
       }
-    },
-    "node_modules/@kuai/cli": {
-      "resolved": "packages/cli",
-      "link": true
-    },
-    "node_modules/@kuai/core": {
-      "resolved": "packages/core",
-      "link": true
-    },
-    "node_modules/@kuai/docker-node": {
-      "resolved": "packages/docker-node",
-      "link": true
-    },
-    "node_modules/@kuai/io": {
-      "resolved": "packages/io",
-      "link": true
-    },
-    "node_modules/@kuai/models": {
-      "resolved": "packages/models",
-      "link": true
-    },
-    "node_modules/@kuai/typeorm": {
-      "resolved": "packages/typeorm",
-      "link": true
     },
     "node_modules/@lerna/add": {
       "version": "6.4.0",
@@ -12881,11 +12881,11 @@
       }
     },
     "packages/cli": {
-      "name": "@kuai/cli",
+      "name": "@ckb-js/kuai-cli",
       "version": "0.0.1",
       "license": "MIT",
       "dependencies": {
-        "@kuai/core": "0.0.1",
+        "@ckb-js/kuai-core": "0.0.1",
         "commander": "9.4.1"
       },
       "bin": {
@@ -12896,11 +12896,11 @@
       }
     },
     "packages/core": {
-      "name": "@kuai/core",
+      "name": "@ckb-js/kuai-core",
       "version": "0.0.1",
       "license": "MIT",
       "dependencies": {
-        "@kuai/docker-node": "0.0.1",
+        "@ckb-js/kuai-docker-node": "0.0.1",
         "chalk": "4.1.2",
         "enquirer": "2.3.6",
         "find-up": "5.0.0",
@@ -12911,7 +12911,7 @@
       }
     },
     "packages/docker-node": {
-      "name": "@kuai/docker-node",
+      "name": "@ckb-js/kuai-docker-node",
       "version": "0.0.1",
       "license": "MIT",
       "dependencies": {
@@ -12922,7 +12922,7 @@
       }
     },
     "packages/io": {
-      "name": "@kuai/io",
+      "name": "@ckb-js/kuai-io",
       "version": "0.0.1",
       "license": "MIT",
       "dependencies": {
@@ -12938,7 +12938,7 @@
       }
     },
     "packages/models": {
-      "name": "@kuai/models",
+      "name": "@ckb-js/kuai-models",
       "version": "0.0.1",
       "license": "MIT",
       "dependencies": {
@@ -12955,7 +12955,7 @@
       }
     },
     "packages/typeorm": {
-      "name": "@kuai/typeorm",
+      "name": "@ckb-js/kuai-typeorm",
       "version": "0.0.1",
       "license": "MIT",
       "dependencies": {
@@ -13444,6 +13444,72 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true
     },
+    "@ckb-js/kuai-cli": {
+      "version": "file:packages/cli",
+      "requires": {
+        "@ckb-js/kuai-core": "0.0.1",
+        "commander": "9.4.1",
+        "ts-node": "10.9.1"
+      }
+    },
+    "@ckb-js/kuai-core": {
+      "version": "file:packages/core",
+      "requires": {
+        "@ckb-js/kuai-docker-node": "0.0.1",
+        "@types/lodash": "4.14.191",
+        "chalk": "4.1.2",
+        "enquirer": "2.3.6",
+        "find-up": "5.0.0",
+        "lodash": "4.17.21"
+      }
+    },
+    "@ckb-js/kuai-docker-node": {
+      "version": "file:packages/docker-node",
+      "requires": {
+        "@types/dockerode": "3.3.14",
+        "dockerode": "3.3.4"
+      }
+    },
+    "@ckb-js/kuai-io": {
+      "version": "file:packages/io",
+      "requires": {
+        "@ckb-lumos/rpc": "0.19.0",
+        "@types/koa-compose": "3.2.5",
+        "@types/koa-router": "7.4.4",
+        "koa": "2.14.1",
+        "koa-compose": "4.1.0",
+        "koa-router": "12.0.0",
+        "rxjs": "7.8.0"
+      }
+    },
+    "@ckb-js/kuai-models": {
+      "version": "file:packages/models",
+      "requires": {
+        "@ckb-lumos/codec": "0.19.0",
+        "@jest/globals": "29.3.1",
+        "bignumber.js": "9.1.1",
+        "inversify": "6.0.1",
+        "ioredis": "5.2.4",
+        "reflect-metadata": "0.1.13",
+        "tslib": "2.4.1",
+        "typescript": "4.9.4"
+      }
+    },
+    "@ckb-js/kuai-typeorm": {
+      "version": "file:packages/typeorm",
+      "requires": {
+        "@jest/globals": "29.3.1",
+        "inversify": "6.0.1",
+        "mysql": "2.18.1",
+        "pg": "8.8.0",
+        "reflect-metadata": "0.1.13",
+        "rxjs": "7.8.0",
+        "ts-node": "10.9.1",
+        "tslib": "2.4.1",
+        "typeorm": "0.3.11",
+        "typescript": "4.9.4"
+      }
+    },
     "@ckb-lumos/base": {
       "version": "0.19.0",
       "resolved": "https://registry.npmjs.org/@ckb-lumos/base/-/base-0.19.0.tgz",
@@ -13930,72 +13996,6 @@
       "requires": {
         "@jridgewell/resolve-uri": "3.1.0",
         "@jridgewell/sourcemap-codec": "1.4.14"
-      }
-    },
-    "@kuai/cli": {
-      "version": "file:packages/cli",
-      "requires": {
-        "@kuai/core": "0.0.1",
-        "commander": "9.4.1",
-        "ts-node": "10.9.1"
-      }
-    },
-    "@kuai/core": {
-      "version": "file:packages/core",
-      "requires": {
-        "@kuai/docker-node": "0.0.1",
-        "@types/lodash": "4.14.191",
-        "chalk": "4.1.2",
-        "enquirer": "2.3.6",
-        "find-up": "5.0.0",
-        "lodash": "4.17.21"
-      }
-    },
-    "@kuai/docker-node": {
-      "version": "file:packages/docker-node",
-      "requires": {
-        "@types/dockerode": "3.3.14",
-        "dockerode": "3.3.4"
-      }
-    },
-    "@kuai/io": {
-      "version": "file:packages/io",
-      "requires": {
-        "@ckb-lumos/rpc": "0.19.0",
-        "@types/koa-compose": "3.2.5",
-        "@types/koa-router": "7.4.4",
-        "koa": "2.14.1",
-        "koa-compose": "4.1.0",
-        "koa-router": "12.0.0",
-        "rxjs": "7.8.0"
-      }
-    },
-    "@kuai/models": {
-      "version": "file:packages/models",
-      "requires": {
-        "@ckb-lumos/codec": "0.19.0",
-        "@jest/globals": "29.3.1",
-        "bignumber.js": "9.1.1",
-        "inversify": "6.0.1",
-        "ioredis": "5.2.4",
-        "reflect-metadata": "0.1.13",
-        "tslib": "2.4.1",
-        "typescript": "4.9.4"
-      }
-    },
-    "@kuai/typeorm": {
-      "version": "file:packages/typeorm",
-      "requires": {
-        "@jest/globals": "29.3.1",
-        "inversify": "6.0.1",
-        "mysql": "2.18.1",
-        "pg": "8.8.0",
-        "reflect-metadata": "0.1.13",
-        "rxjs": "7.8.0",
-        "ts-node": "10.9.1",
-        "tslib": "2.4.1",
-        "typeorm": "0.3.11",
-        "typescript": "4.9.4"
       }
     },
     "@lerna/add": {

--- a/packages/cli/__tests__/__fixtures__/kuai-config-case/kuai.config.ts
+++ b/packages/cli/__tests__/__fixtures__/kuai-config-case/kuai.config.ts
@@ -1,4 +1,4 @@
-import { task, subtask, KuaiConfig, paramTypes } from '@kuai/core'
+import { task, subtask, KuaiConfig, paramTypes } from '@ckb-js/kuai-core'
 
 task('demo-task1')
   .addParam('paramA', 'a custom param', 'default value')

--- a/packages/cli/__tests__/index.ts
+++ b/packages/cli/__tests__/index.ts
@@ -15,7 +15,7 @@ describe('kuai cli', () => {
 
   afterAll(() => {
     execSync('npx kuai node stop')
-    execSync('npm unlink -g @kuai/cli')
+    execSync('npm unlink -g @ckb-js/kuai-cli')
   })
 
   test('ckb node listening port', async () => {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@kuai/cli",
+  "name": "@ckb-js/kuai-cli",
   "version": "0.0.1",
   "license": "MIT",
   "main": "lib/main.js",
@@ -11,7 +11,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@kuai/core": "0.0.1",
+    "@ckb-js/kuai-core": "0.0.1",
     "commander": "9.4.1"
   },
   "devDependencies": {

--- a/packages/cli/src/main.ts
+++ b/packages/cli/src/main.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 import { Command, createOption, Option } from 'commander'
-import { TaskParam, TaskArguments, initialKuai, paramTypes, KuaiArguments } from '@kuai/core'
+import { TaskParam, TaskArguments, initialKuai, paramTypes, KuaiArguments } from '@ckb-js/kuai-core'
 
 const KUAI_GLOBAL_PARAMS: Array<TaskParam> = [
   {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@kuai/core",
+  "name": "@ckb-js/kuai-core",
   "version": "0.0.1",
   "license": "MIT",
   "main": "lib/index.js",
@@ -8,7 +8,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@kuai/docker-node": "0.0.1",
+    "@ckb-js/kuai-docker-node": "0.0.1",
     "chalk": "4.1.2",
     "enquirer": "2.3.6",
     "find-up": "5.0.0",

--- a/packages/core/sample-projects/kuai.config.ts
+++ b/packages/core/sample-projects/kuai.config.ts
@@ -1,4 +1,4 @@
-import { KuaiConfig } from '@kuai/core';
+import { KuaiConfig } from '@ckb-js/kuai-core';
 
 const config: KuaiConfig = {};
 

--- a/packages/core/src/builtin-tasks/node.ts
+++ b/packages/core/src/builtin-tasks/node.ts
@@ -1,6 +1,6 @@
 import { task, subtask } from '../config/config-env'
 import { paramTypes } from '../params'
-import { CkbDockerNetwork } from '@kuai/docker-node'
+import { CkbDockerNetwork } from '@ckb-js/kuai-docker-node'
 import { KuaiError } from '../errors'
 import { ERRORS } from '../errors-list'
 import '../type/runtime'

--- a/packages/docker-node/package.json
+++ b/packages/docker-node/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@kuai/docker-node",
+  "name": "@ckb-js/kuai-docker-node",
   "version": "0.0.1",
   "license": "MIT",
   "description": "kuai run dev node by docker",

--- a/packages/io/package.json
+++ b/packages/io/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@kuai/io",
+  "name": "@ckb-js/kuai-io",
   "version": "0.0.1",
   "description": "kuai io layer",
   "homepage": "https://github.com/ckb-js/kuai#readme",

--- a/packages/models/README.md
+++ b/packages/models/README.md
@@ -1,11 +1,11 @@
-# `@kuai/models`
+# `@ckb-js/kuai-models`
 
 > TODO: description
 
 ## Usage
 
 ```
-const models = require('@kuai/models');
+const models = require('@ckb-js/kuai-models');
 
 // TODO: DEMONSTRATE API
 ```

--- a/packages/models/package.json
+++ b/packages/models/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@kuai/models",
+  "name": "@ckb-js/kuai-models",
   "version": "0.0.1",
   "description": "Models of Kuai runtime",
   "author": "Keith <keithwhisper@gmail.com>",

--- a/packages/typeorm/README.md
+++ b/packages/typeorm/README.md
@@ -9,7 +9,7 @@ We assume that you are familiar with [TypeOrm](https://github.com/typeorm/typeor
 Install the required dependencies.
 
 ```
-npm install --save @kuai/typeorm
+npm install --save @ckb-js/kuai-typeorm
 ```
 
 We need at least one entity, so we define the `User` entity firstly.
@@ -36,7 +36,7 @@ To use `Datasource` and `EntityManager`, we need to bind them to the container u
 ```
 // app.ts
 
-import { TypeOrmManager } from '@kuai/typeorm'
+import { TypeOrmManager } from '@ckb-js/kuai-typeorm'
 import { User } from './user.entity'
 
 await TypeOrmManager.importRoot({
@@ -78,7 +78,7 @@ And the `UserService` also needed to be bounded to the container by `@Service()`
 // user.service.ts
 
 import { DataSource, EntityManager, Repository } from 'typeorm'
-import { InjectDataSource, InjectRepository, InjectEntityManager, Service } from '@kuai/typeorm'
+import { InjectDataSource, InjectRepository, InjectEntityManager, Service } from '@ckb-js/kuai-typeorm'
 import { User } from './user.entity'
 
 @Service()
@@ -127,7 +127,7 @@ It's time to get the created `UserService` from the container by `container.get<
 ```
 // app.ts
 
-import { contanier } from '@kuai/typeorm'
+import { contanier } from '@ckb-js/kuai-typeorm'
 
 const userOne = new User()
 userOne.id = 1

--- a/packages/typeorm/package.json
+++ b/packages/typeorm/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@kuai/typeorm",
+  "name": "@ckb-js/kuai-typeorm",
   "version": "0.0.1",
   "description": "Inject TypeOrm by InversifyJs",
   "author": "felicityin <yinjingping2022@gmail.com>",


### PR DESCRIPTION
use '@ckb-js' as scope of kuai packages because '@kuai' has been occupied.

Ref: https://github.com/ckb-js/kuai/issues/27