### PR TITLE
feat(@kuai/core): project template integrate `kuai/io` & `kuai/models`

### DIFF
--- a/packages/core/recommended-package.json
+++ b/packages/core/recommended-package.json
@@ -1,3 +1,7 @@
 {
-  "name": "kuai-project"
+  "name": "kuai-project",
+  "scripts": {
+    "build": "tsc",
+    "test": "jest"
+  }
 }

--- a/packages/core/sample-projects/README.md
+++ b/packages/core/sample-projects/README.md
@@ -1,3 +1,11 @@
 # Sample Kuai Project
 
 This project demonstrates a basic kuai use case.
+
+## Run server
+
+```
+npm run build
+
+node ./dist/src/main.js
+```

--- a/packages/core/sample-projects/kuai.config.ts
+++ b/packages/core/sample-projects/kuai.config.ts
@@ -1,5 +1,7 @@
 import { KuaiConfig } from '@ckb-js/kuai-core';
 
-const config: KuaiConfig = {};
+const config: KuaiConfig = {
+  port: 3000,
+};
 
 export default config;

--- a/packages/core/sample-projects/src/actors/app.ts
+++ b/packages/core/sample-projects/src/actors/app.ts
@@ -12,7 +12,6 @@ export type AppMessage = HelloMessage;
 @ActorProvider({ name: 'app' })
 export class CustomActor extends Actor<object, MessagePayload<AppMessage>> {
   handleCall = (_msg: ActorMessage<MessagePayload<AppMessage>>): void => {
-    console.log('app actor handleCall');
     switch (_msg.payload?.value?.type) {
       case 'hello': {
         const name = _msg.payload?.value?.hello.name;

--- a/packages/core/sample-projects/src/actors/app.ts
+++ b/packages/core/sample-projects/src/actors/app.ts
@@ -1,0 +1,34 @@
+import { Actor, ActorMessage, MessagePayload, ActorProvider } from '@ckb-js/kuai-models';
+
+interface HelloMessage {
+  type: 'hello';
+  hello: {
+    name: string;
+  };
+}
+
+export type AppMessage = HelloMessage;
+
+@ActorProvider({ name: 'app' })
+export class CustomActor extends Actor<object, MessagePayload<AppMessage>> {
+  handleCall = (_msg: ActorMessage<MessagePayload<AppMessage>>): void => {
+    console.log('app actor handleCall');
+    switch (_msg.payload?.value?.type) {
+      case 'hello': {
+        const name = _msg.payload?.value?.hello.name;
+        this.hello(name);
+        break;
+      }
+      default:
+        break;
+    }
+  };
+
+  hello = (name?: string) => {
+    if (name) {
+      return `hello ${name}`;
+    }
+
+    return `hello world`;
+  };
+}

--- a/packages/core/sample-projects/src/actors/index.ts
+++ b/packages/core/sample-projects/src/actors/index.ts
@@ -1,0 +1,6 @@
+import { Registry } from '@ckb-js/kuai-models';
+
+const appRegistry = new Registry();
+appRegistry.load(__dirname);
+
+export { appRegistry };

--- a/packages/core/sample-projects/src/app.controller.ts
+++ b/packages/core/sample-projects/src/app.controller.ts
@@ -1,0 +1,27 @@
+import { KuaiRouter } from '@ckb-js/kuai-io';
+import { appRegistry } from './actors';
+import { Actor } from '@ckb-js/kuai-models';
+
+const router = new KuaiRouter();
+
+router.get('/', async (ctx) => {
+  const appActor = appRegistry.find('local://app');
+
+  if (!appActor) {
+    return ctx.err('not found app actor');
+  }
+
+  await Actor.call(appActor.ref.uri, appActor.ref, {
+    pattern: 'normal',
+    value: {
+      type: 'hello',
+      hello: {
+        name: ctx?.payload?.query?.name,
+      },
+    },
+  });
+
+  ctx.ok(`hello ${ctx?.payload?.query?.name || 'world'}`);
+});
+
+export { router };

--- a/packages/core/sample-projects/src/main.ts
+++ b/packages/core/sample-projects/src/main.ts
@@ -1,0 +1,42 @@
+import Koa from 'koa';
+import { koaBody } from 'koa-body';
+import { initialKuai } from '@ckb-js/kuai-core';
+import { KoaRouterAdapter, CoR } from '@ckb-js/kuai-io';
+import { router } from './app.controller';
+import './type-extends';
+
+async function bootstrap() {
+  const kuaiCtx = await initialKuai();
+  const kuaiEnv = kuaiCtx.getRuntimeEnvironment();
+  const port = kuaiEnv.config?.port || 3000;
+
+  const app = new Koa();
+  app.use(koaBody());
+
+  // init kuai io
+  const cor = new CoR();
+  cor.use(router.middleware());
+
+  const koaRouterAdapter = new KoaRouterAdapter(cor);
+
+  app.use(koaRouterAdapter.routes()).use(koaRouterAdapter.allowedMethods());
+
+  const server = app.listen(port, function () {
+    const address = (() => {
+      const _address = server.address();
+      if (!_address) {
+        return '';
+      }
+
+      if (typeof _address === 'string') {
+        return _address;
+      }
+
+      return `http://${_address.address}:${_address.port}`;
+    })();
+
+    console.log(`kuai app listening at ${address}`);
+  });
+}
+
+bootstrap();

--- a/packages/core/sample-projects/src/type-extends.ts
+++ b/packages/core/sample-projects/src/type-extends.ts
@@ -1,0 +1,7 @@
+import '@ckb-js/kuai-core';
+
+declare module '@ckb-js/kuai-core' {
+  export interface KuaiConfig {
+    port?: number;
+  }
+}

--- a/packages/core/sample-projects/tsconfig.json
+++ b/packages/core/sample-projects/tsconfig.json
@@ -3,8 +3,11 @@
     "target": "es2019",
     "module": "commonjs",
     "esModuleInterop": true,
+    "outDir": "dist",
     "forceConsistentCasingInFileNames": true,
+    "experimentalDecorators": true,
     "strict": true,
     "skipLibCheck": true
-  }
+  },
+  "exclude": ["node_modules"]
 }

--- a/packages/core/src/type/runtime.ts
+++ b/packages/core/src/type/runtime.ts
@@ -6,7 +6,7 @@ export interface KuaiArguments {
   network?: string
 }
 
-export type KuaiConfig = {
+export interface KuaiConfig {
   kuaiArguments?: KuaiArguments
   network?: HttpNetworkConfig
 }

--- a/packages/core/src/type/runtime.ts
+++ b/packages/core/src/type/runtime.ts
@@ -20,6 +20,7 @@ export type RunTaskFunction = (name: string, taskArguments?: TaskArguments) => P
 export type EnvironmentExtender = (env: RuntimeEnvironment) => void
 
 export interface RuntimeEnvironment {
+  // TODO: change to generate type
   readonly config: KuaiConfig
   readonly tasks: Record<string, Task>
   readonly run: RunTaskFunction


### PR DESCRIPTION
- Project template integrated with `kuai/io` and `kuai/models`
- Added a  built-in hello-world controller 
- Added automatic download of dependencies at project initial

## How to start in local:
 1. Compile kuai: run `lerna run build` in the `kuai` project root directory
 2. Link the local packages: `npm link ./packages/core ./packages/cli ./packages/models ./packages/io`
 3. Switch to the project directory and run `kuai init`.