### PR TITLE
docs: add default module description in main modules of samples/mvp

### DIFF
--- a/packages/samples/mvp-dapp/kuai.config.js
+++ b/packages/samples/mvp-dapp/kuai.config.js
@@ -1,3 +1,9 @@
+/**
+ * @module kuai.config
+ * @description
+ * Kuai configuration file
+ */
+
 require('dotenv').config()
 
 module.exports = {

--- a/packages/samples/mvp-dapp/src/actors/index.ts
+++ b/packages/samples/mvp-dapp/src/actors/index.ts
@@ -1,3 +1,11 @@
+/**
+ * @module src/actors
+ * @description
+ * This module works as the entry of all actor models in the application.
+ * It loads all actor models in directory into the registry for automatic initialization.
+ * It also exports the registry instance so that other modules can use it.
+ */
+
 import { Registry } from '@ckb-js/kuai-models'
 
 const appRegistry = new Registry()

--- a/packages/samples/mvp-dapp/src/actors/omnilock.model.ts
+++ b/packages/samples/mvp-dapp/src/actors/omnilock.model.ts
@@ -1,3 +1,9 @@
+/**
+ * @module src/actors/omnilock.model
+ * @description
+ * This is the actor model for omnilock, which is used to gather omnilock cells to generate record models.
+ */
+
 import {
   ActorProvider,
   Omnilock,

--- a/packages/samples/mvp-dapp/src/actors/record.model.ts
+++ b/packages/samples/mvp-dapp/src/actors/record.model.ts
@@ -1,3 +1,9 @@
+/**
+ * @module src/actors/record.model
+ * @description
+ * This is the actor model for record, which is used to store data in a json format.
+ */
+
 import {
   ActorProvider,
   Lock,

--- a/packages/samples/mvp-dapp/src/app.controller.ts
+++ b/packages/samples/mvp-dapp/src/app.controller.ts
@@ -1,3 +1,10 @@
+/**
+ * @module src/app.controller
+ * @description
+ * This is the controller for the application.
+ * It defines the routes to specific models.
+ */
+
 import type { StoreType } from './actors/record.model'
 import { KuaiRouter } from '@ckb-js/kuai-io'
 import { HexString, helpers } from '@ckb-lumos/lumos'

--- a/packages/samples/mvp-dapp/src/chain-source.ts
+++ b/packages/samples/mvp-dapp/src/chain-source.ts
@@ -1,3 +1,10 @@
+/**
+ * @module src/chain-source
+ * @description
+ * This module defines the chain source for the application.
+ * A chain source could be a CKB indexer.
+ */
+
 import type { ChainSource } from '@ckb-js/kuai-io/lib/types'
 import { Script, RPC, BI } from '@ckb-lumos/lumos'
 import type { CKBComponents } from '@ckb-lumos/rpc/lib/types/api'

--- a/packages/samples/mvp-dapp/src/const.ts
+++ b/packages/samples/mvp-dapp/src/const.ts
@@ -1,3 +1,9 @@
+/**
+ * @module src/const
+ * @description
+ * This module defines the constants used in the application.
+ */
+
 import { bytes } from '@ckb-lumos/codec'
 
 export const DAPP_DATA_PREFIX = bytes.hexify(Buffer.from('mvp-dapp'))

--- a/packages/samples/mvp-dapp/src/exception.ts
+++ b/packages/samples/mvp-dapp/src/exception.ts
@@ -1,3 +1,10 @@
+/**
+ * @module src/exception
+ * @description
+ * This module defines the exception handler for the application.
+ * It catches all exceptions and returns the error message to the client.
+ */
+
 import { Context, Next } from 'koa'
 import { MvpResponse } from './response'
 import { isHttpError } from 'http-errors'

--- a/packages/samples/mvp-dapp/src/main.ts
+++ b/packages/samples/mvp-dapp/src/main.ts
@@ -1,3 +1,10 @@
+/**
+ * @module src/main
+ * @description
+ * This module is the entry of the application.
+ * It initializes the kuai context and starts the application.
+ */
+
 import Koa from 'koa'
 import { koaBody } from 'koa-body'
 import { initialKuai, getGenesisScriptsConfig } from '@ckb-js/kuai-core'

--- a/packages/samples/mvp-dapp/src/response.ts
+++ b/packages/samples/mvp-dapp/src/response.ts
@@ -1,3 +1,10 @@
+/**
+ * @module src/response
+ * @description
+ * This module defines the response format of the application.
+ * It is used to wrap the response data and return to the client.
+ */
+
 export class MvpResponse<T> {
   code: string
   data: T

--- a/packages/samples/mvp-dapp/src/type-extends.d.ts
+++ b/packages/samples/mvp-dapp/src/type-extends.d.ts
@@ -1,3 +1,9 @@
+/**
+ * @module src/type-extends
+ * @description
+ * This module defines the type extends for the application.
+ */
+
 import '@ckb-js/kuai-core'
 import type { Config } from '@ckb-lumos/config-manager'
 

--- a/packages/samples/mvp-dapp/src/views/tx.view.ts
+++ b/packages/samples/mvp-dapp/src/views/tx.view.ts
@@ -1,3 +1,9 @@
+/**
+ * @module src/views/tx.view
+ * @description
+ * This module works as the view layer and is used to generate transaction skeleton.
+ */
+
 import { Cell, helpers, config } from '@ckb-lumos/lumos'
 import { SECP_SIGNATURE_PLACEHOLDER, OMNILOCK_SIGNATURE_PLACEHOLDER } from '@ckb-lumos/common-scripts/lib/helper'
 import { blockchain } from '@ckb-lumos/base'


### PR DESCRIPTION
This PR adds default module-level description in main modules of samples/mvp

Ref: https://github.com/ckb-js/kuai/issues/244#issuecomment-1541503555