### PR TITLE
feat: update mvp-dapp by the deployed contract

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3623,15 +3623,6 @@
       "integrity": "sha512-NzUnlZexiaH/46WDhANlyR2bXRopNg4F/zuSA3OpZnllCUgRaOF2znDioDWrmbNVsuZk6l9pMquQB38cfBZwkQ==",
       "dev": true
     },
-    "node_modules/bignumber.js": {
-      "version": "9.1.1",
-      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.1.1.tgz",
-      "integrity": "sha512-pHm4LsMJ6lzgNGVfZHjMoO8sdoRhOzOH4MLmY65Jg70bpxCKu5iOHNJyfF6OyvYw7t8Fpf35RuzUyqnQsj8Vig==",
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/bl": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
@@ -14482,7 +14473,6 @@
         "@ckb-lumos/base": "0.19.0",
         "@ckb-lumos/codec": "0.19.0",
         "@ckb-lumos/experiment-tx-assembler": "0.19.0",
-        "bignumber.js": "9.1.1",
         "inversify": "6.0.1",
         "ioredis": "5.3.2",
         "lodash": "4.17.21",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,8 +13,8 @@
         "packages/samples/*"
       ],
       "devDependencies": {
-        "@typescript-eslint/eslint-plugin": "^5.59.11",
-        "@typescript-eslint/parser": "^5.59.11",
+        "@typescript-eslint/eslint-plugin": "5.59.11",
+        "@typescript-eslint/parser": "5.59.11",
         "eslint": "8.42.0",
         "husky": "8.0.3",
         "jest": "29.5.0",

--- a/packages/models/__tests__/store/json-storage.ts
+++ b/packages/models/__tests__/store/json-storage.ts
@@ -1,7 +1,6 @@
-import BigNumber from 'bignumber.js'
 import { describe, it, expect, jest } from '@jest/globals'
-import { addMarkForStorage, JSONStorage } from '../../src'
-import { UnexpectedParamsException, UnexpectedTypeException } from '../../src/exceptions'
+import { JSONStorage } from '../../src'
+import { UnexpectedParamsException } from '../../src/exceptions'
 
 const mockXAdd = jest.fn()
 const mockXRead = jest.fn<() => void>()
@@ -22,8 +21,8 @@ describe('test json storage', () => {
     })
 
     it('only one layer', () => {
-      const storage = new JSONStorage<{ data: { a: BigNumber; b: string; c: boolean; d: boolean; e: BigNumber } }>()
-      const data = { a: BigNumber(1), b: 'b', c: true, d: false, e: BigNumber('100') }
+      const storage = new JSONStorage<{ data: { b: string } }>()
+      const data = { b: 'b' }
       const res = storage.serialize({ data })
       const original = storage.deserialize(res)
       Object.keys(data).forEach((key) => {
@@ -33,8 +32,8 @@ describe('test json storage', () => {
     })
 
     it('more than one layer', () => {
-      const storage = new JSONStorage<{ data: { lay: { b: string; c: boolean; d: boolean; e: BigNumber } } }>()
-      const data = { b: 'b', c: true, d: false, e: BigNumber('100') }
+      const storage = new JSONStorage<{ data: { lay: { b: string; e: string } } }>()
+      const data = { b: 'b', e: '100' }
       const res = storage.serialize({ data: { lay: data } })
       const original = storage.deserialize(res)
       Object.keys(data).forEach((key) => {
@@ -52,8 +51,8 @@ describe('test json storage', () => {
       expect(original).toStrictEqual({ witness: {} })
     })
     it('only one layer', () => {
-      const storage = new JSONStorage<{ witness: { b: string; c: boolean; d: boolean; e: BigNumber } }>()
-      const witness = { b: 'b', c: true, d: false, e: BigNumber('100') }
+      const storage = new JSONStorage<{ witness: { b: string; e: string } }>()
+      const witness = { b: 'b', e: '100' }
       const res = storage.serialize({ witness })
       const original = storage.deserialize(res)
       Object.keys(witness).forEach((key) => {
@@ -64,9 +63,9 @@ describe('test json storage', () => {
 
     it('more than one layer', () => {
       const storage = new JSONStorage<{
-        witness: { lay: { b: string; c: boolean; d: boolean; e: BigNumber } }
+        witness: { lay: { b: string } }
       }>()
-      const witness = { b: 'b', c: true, d: false, e: BigNumber('100') }
+      const witness = { b: 'b' }
       const res = storage.serialize({ witness: { lay: witness } })
       const original = storage.deserialize(res)
       Object.keys(witness).forEach((key) => {
@@ -86,17 +85,17 @@ describe('test json storage', () => {
 
     it('more than one layer', () => {
       const storage = new JSONStorage<{
-        data: BigNumber
-        witness: { lay: { b: string; c: boolean; d: boolean; e: BigNumber } }
+        data: string
+        witness: { lay: { b: string } }
       }>()
-      const witness = { b: 'b', c: true, d: false, e: BigNumber('100') }
-      const res = storage.serialize({ data: BigNumber(10), witness: { lay: witness } })
+      const witness = { b: 'b' }
+      const res = storage.serialize({ data: '10', witness: { lay: witness } })
       const original = storage.deserialize(res)
       Object.keys(witness).forEach((key) => {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         expect((original.witness.lay as any)[key]).toEqual((witness as any)[key])
       })
-      expect(original.data).toStrictEqual(BigNumber(10))
+      expect(original.data).toStrictEqual('10')
     })
   })
 
@@ -106,23 +105,6 @@ describe('test json storage', () => {
       const res = storage.serialize({})
       expect(res).toStrictEqual(Buffer.from(JSON.stringify({})))
     })
-    it('serialize with null in data', () => {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      expect(() => storage.serialize({ a: null } as any)).toThrow(new UnexpectedTypeException('null'))
-    })
-    it('serialize with null', () => {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      expect(() => (storage.serialize as any)(null)).toThrow(new UnexpectedTypeException('null'))
-    })
-    it('serialize with undefined', () => {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      expect(() => (storage.serialize as any)()).toThrow(new UnexpectedTypeException('undefined'))
-    })
-    it('deserialize with null in data', () => {
-      expect(() => storage.deserialize(Buffer.from(JSON.stringify({ a: null })))).toThrow(
-        new UnexpectedTypeException('null'),
-      )
-    })
     it('deserialize with null', () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       expect(() => (storage.deserialize as any)(null)).toThrow(new UnexpectedParamsException('null'))
@@ -130,49 +112,6 @@ describe('test json storage', () => {
     it('deserialize with undefined', () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       expect(() => (storage.deserialize as any)()).toThrow(new UnexpectedParamsException('undefined'))
-    })
-  })
-
-  describe('test addMarkForStorage', () => {
-    it('is null', () => {
-      try {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        addMarkForStorage(null as any)
-      } catch (error) {
-        expect(error).toBeInstanceOf(UnexpectedTypeException)
-      }
-    })
-    it('is undefined', () => {
-      try {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        addMarkForStorage(null as any)
-      } catch (error) {
-        expect(error).toBeInstanceOf(UnexpectedTypeException)
-      }
-    })
-    it('is BigNumber Array', () => {
-      const res = addMarkForStorage([BigNumber(10), BigNumber(20)])
-      expect(res).toStrictEqual(['210', '220'])
-    })
-    it('is simple obj', () => {
-      const res = addMarkForStorage({ a: 's', b: true, c: BigNumber(10) })
-      expect(res).toStrictEqual({
-        a: '0s',
-        b: '1true',
-        c: '210',
-      })
-    })
-    it('is complex obj', () => {
-      const res = addMarkForStorage({
-        a: [BigNumber(10), BigNumber(20)],
-        b: { c: { e: BigNumber(20) }, d: [BigNumber(20)] },
-        e: BigNumber(10),
-      })
-      expect(res).toStrictEqual({
-        a: ['210', '220'],
-        b: { c: { e: '220' }, d: ['220'] },
-        e: '210',
-      })
     })
   })
 })

--- a/packages/models/__tests__/store/store.ts
+++ b/packages/models/__tests__/store/store.ts
@@ -1,7 +1,6 @@
 import { bytes, molecule, number } from '@ckb-lumos/codec'
 import type { Cell, HexString, OutPoint, Script } from '@ckb-lumos/base'
 import { BI } from '@ckb-lumos/bi'
-import BigNumber from 'bignumber.js'
 import { describe, it, expect, beforeEach, jest } from '@jest/globals'
 import { NoCellToUseException, NonExistentException, NonStorageInstanceException } from '../../src/exceptions'
 import {
@@ -61,13 +60,7 @@ class StorageCustom<T extends CustomType = CustomType> extends ChainStorage<T> {
 
   isSimpleType(value: unknown): boolean {
     const vType = typeof value
-    return (
-      vType === 'string' ||
-      vType === 'boolean' ||
-      vType === 'number' ||
-      vType === 'undefined' ||
-      value instanceof BigNumber
-    )
+    return vType === 'string' || vType === 'boolean' || vType === 'number' || vType === 'undefined'
   }
 }
 
@@ -151,40 +144,40 @@ describe('test store', () => {
   describe('use json storage', () => {
     describe('test init chain data', () => {
       it('init with data', () => {
-        const store = new JSONStore<{ data: { a: BigNumber } }>({ data: true })
-        const chainData = store.initOnChain({ data: { a: BigNumber(20) } })
-        const expected = bytes.hexify(new JSONStorage().serialize({ a: BigNumber(20) }))
+        const store = new JSONStore<{ data: { a: string } }>({ data: true })
+        const chainData = store.initOnChain({ data: { a: '20' } })
+        const expected = bytes.hexify(new JSONStorage().serialize({ a: '20' }))
         expect(chainData.data).toBe(expected)
         expect(chainData.witness).toBeUndefined()
         expect(chainData.lockArgs).toBeUndefined()
         expect(chainData.typeArgs).toBeUndefined()
       })
       it('init with witness', () => {
-        const store = new JSONStore<{ witness: { a: BigNumber } }>({ witness: true })
-        const chainData = store.initOnChain({ witness: { a: BigNumber(20) } })
-        const expected = bytes.hexify(new JSONStorage().serialize({ a: BigNumber(20) }))
+        const store = new JSONStore<{ witness: { a: string } }>({ witness: true })
+        const chainData = store.initOnChain({ witness: { a: '20' } })
+        const expected = bytes.hexify(new JSONStorage().serialize({ a: '20' }))
         expect(chainData.witness).toBe(expected)
         expect(chainData.data).toBeUndefined()
         expect(chainData.lockArgs).toBeUndefined()
         expect(chainData.typeArgs).toBeUndefined()
       })
       it('init with lock', () => {
-        const store = new JSONStore<{ lockArgs: BigNumber }>({
+        const store = new JSONStore<{ lockArgs: string }>({
           lockArgs: true,
         })
-        const chainData = store.initOnChain({ lockArgs: BigNumber(20) })
-        const expectedArgs = bytes.hexify(new JSONStorage().serialize(BigNumber(20)))
+        const chainData = store.initOnChain({ lockArgs: '20' })
+        const expectedArgs = bytes.hexify(new JSONStorage().serialize('20'))
         expect(chainData.lockArgs).toBe(expectedArgs)
         expect(chainData.data).toBeUndefined()
         expect(chainData.witness).toBeUndefined()
         expect(chainData.typeArgs).toBeUndefined()
       })
       it('init with type', () => {
-        const store = new JSONStore<{ typeArgs: BigNumber }>({
+        const store = new JSONStore<{ typeArgs: string }>({
           typeArgs: true,
         })
-        const chainData = store.initOnChain({ typeArgs: BigNumber(20) })
-        const expectedArgs = bytes.hexify(new JSONStorage().serialize(BigNumber(20)))
+        const chainData = store.initOnChain({ typeArgs: '20' })
+        const expectedArgs = bytes.hexify(new JSONStorage().serialize('20'))
         expect(chainData.typeArgs).toBe(expectedArgs)
         expect(chainData.data).toBeUndefined()
         expect(chainData.witness).toBeUndefined()
@@ -194,38 +187,38 @@ describe('test store', () => {
 
     describe('test handleCall with add', () => {
       it('add in section store', () => {
-        const store = new JSONStore<{ data: { a: BigNumber } }>({ data: true })
-        const initValue = { a: BigNumber(1) }
+        const store = new JSONStore<{ data: { a: string } }>({ data: true })
+        const initValue = { a: '1' }
         const onchainData = store.initOnChain({ data: initValue })
         const sectionStore = store.cloneSection()
         sectionStore.handleCall(createUpdateParams({ data: onchainData.data }))
         expect(sectionStore.get(defaultOutpointString)).toBeUndefined()
       })
       it('add data success', () => {
-        const store = new JSONStore<{ data: { a: BigNumber } }>({ data: true })
-        const initValue = { a: BigNumber(1) }
+        const store = new JSONStore<{ data: { a: string } }>({ data: true })
+        const initValue = { a: '1' }
         const onchainData = store.initOnChain({ data: initValue })
         store.handleCall(createUpdateParams({ data: onchainData.data }))
         expect(store.get(defaultOutpointString)).toStrictEqual({ data: initValue })
       })
       it('add witness success', () => {
-        const store = new JSONStore<{ witness: { a: BigNumber } }>({ witness: true })
-        const initValue = { a: BigNumber(1) }
+        const store = new JSONStore<{ witness: { a: string } }>({ witness: true })
+        const initValue = { a: '1' }
         const onchainData = store.initOnChain({ witness: initValue })
         store.handleCall(createUpdateParams({ witness: onchainData.witness }))
         expect(store.get(defaultOutpointString)).toStrictEqual({ witness: initValue })
       })
       it('add with duplicate add params', () => {
-        const store = new JSONStore<{ data: { a: BigNumber } }>({ data: true })
-        store.handleCall(createUpdateParams({ data: store.initOnChain({ data: { a: BigNumber(1) } }).data }))
-        const initValue = { a: BigNumber(10) }
+        const store = new JSONStore<{ data: { a: string } }>({ data: true })
+        store.handleCall(createUpdateParams({ data: store.initOnChain({ data: { a: '1' } }).data }))
+        const initValue = { a: '10' }
         const onchainData = store.initOnChain({ data: initValue })
         store.handleCall(createUpdateParams({ data: onchainData.data }))
         expect(store.get(defaultOutpointString)).toStrictEqual({ data: initValue })
       })
       it('add lock without offset', () => {
-        const lockStore = new JSONStore<{ lockArgs: BigNumber }>({ lockArgs: true })
-        const initValue = { lockArgs: BigNumber(1) }
+        const lockStore = new JSONStore<{ lockArgs: string }>({ lockArgs: true })
+        const initValue = { lockArgs: '1' }
         const onchainData = lockStore.initOnChain(initValue)
         lockStore.handleCall(
           createUpdateParams({ lock: { args: onchainData.lockArgs, codeHash: '', hashType: 'data' } }),
@@ -233,10 +226,10 @@ describe('test store', () => {
         expect(lockStore.get(defaultOutpointString)).toStrictEqual(initValue)
       })
       it('add lock with offset', () => {
-        const lockStore = new JSONStore<{ lockArgs: { offset: 10; schema: BigNumber } }>({
+        const lockStore = new JSONStore<{ lockArgs: { offset: 10; schema: string } }>({
           lockArgs: { offset: 10 },
         })
-        const initValue = { lockArgs: BigNumber(10) }
+        const initValue = { lockArgs: '10' }
         const onchainData = lockStore.initOnChain(initValue)
         lockStore.handleCall(
           createUpdateParams({ lock: { args: onchainData.lockArgs, codeHash: '', hashType: 'data' } }),
@@ -244,17 +237,17 @@ describe('test store', () => {
         expect(lockStore.get(defaultOutpointString)).toStrictEqual(initValue)
       })
       it('add type without offset', () => {
-        const store = new JSONStore<{ typeArgs: BigNumber }>({ typeArgs: true })
-        const initValue = { typeArgs: BigNumber(1) }
+        const store = new JSONStore<{ typeArgs: string }>({ typeArgs: true })
+        const initValue = { typeArgs: '1' }
         const onchainData = store.initOnChain(initValue)
         store.handleCall(createUpdateParams({ type: { args: onchainData.typeArgs, codeHash: '', hashType: 'data' } }))
         expect(store.get(defaultOutpointString)).toStrictEqual(initValue)
       })
       it('add type with offset', () => {
-        const store = new JSONStore<{ typeArgs: { offset: 10; schema: BigNumber } }>({
+        const store = new JSONStore<{ typeArgs: { offset: 10; schema: string } }>({
           typeArgs: { offset: 10 },
         })
-        const initValue = { typeArgs: BigNumber(10) }
+        const initValue = { typeArgs: '10' }
         const onchainData = store.initOnChain(initValue)
         store.handleCall(createUpdateParams({ type: { args: onchainData.typeArgs, codeHash: '', hashType: 'data' } }))
         expect(store.get(defaultOutpointString)).toStrictEqual(initValue)
@@ -262,9 +255,9 @@ describe('test store', () => {
     })
 
     describe('test handleCall with sub', () => {
-      const store = new JSONStore<{ data: { a: BigNumber } }>({ data: true })
+      const store = new JSONStore<{ data: { a: string } }>({ data: true })
       beforeEach(() => {
-        const initValue = { a: BigNumber(1) }
+        const initValue = { a: '1' }
         const onchainData = store.initOnChain({ data: initValue })
         store.handleCall(createUpdateParams({ data: onchainData.data }))
       })
@@ -280,8 +273,8 @@ describe('test store', () => {
 
     describe('test clone', () => {
       it('clone data and witness', () => {
-        const store = new JSONStore<{ data: { a: BigNumber }; witness: { b: string } }>({ data: true, witness: true })
-        const onchainData = store.initOnChain({ data: { a: BigNumber(1) }, witness: { b: 'BigNumber(20)' } })
+        const store = new JSONStore<{ data: { a: string }; witness: { b: string } }>({ data: true, witness: true })
+        const onchainData = store.initOnChain({ data: { a: '1' }, witness: { b: '20' } })
         store.handleCall(createUpdateParams({ data: onchainData.data, witness: onchainData.witness }))
         const cloneRes = store.clone()
         expect(cloneRes.get(defaultOutpointString) === store.get(defaultOutpointString)).toBeFalsy()
@@ -291,10 +284,10 @@ describe('test store', () => {
         expect(cloneRes.getChainData(defaultOutpointString).witness).toEqual(onchainData.witness)
       })
       it('clone with lock', () => {
-        const store = new JSONStore<{ lockArgs: BigNumber }>({
+        const store = new JSONStore<{ lockArgs: string }>({
           lockArgs: true,
         })
-        const onchainData = store.initOnChain({ lockArgs: BigNumber(1) })
+        const onchainData = store.initOnChain({ lockArgs: '1' })
         store.handleCall(
           createUpdateParams({ lock: { args: onchainData.lockArgs, codeHash: '0x00', hashType: 'type' } }),
         )
@@ -308,10 +301,10 @@ describe('test store', () => {
         expect(cloneRes.getChainData(defaultOutpointString).witness).toBeUndefined()
       })
       it('clone with type and offset', () => {
-        const store = new JSONStore<{ typeArgs: BigNumber }>({
+        const store = new JSONStore<{ typeArgs: string }>({
           typeArgs: true,
         })
-        const onchainData = store.initOnChain({ typeArgs: BigNumber(1) })
+        const onchainData = store.initOnChain({ typeArgs: '1' })
         store.handleCall(
           createUpdateParams({ type: { args: onchainData.typeArgs, codeHash: '0x00', hashType: 'type' } }),
         )
@@ -328,10 +321,10 @@ describe('test store', () => {
 
     describe('test get', () => {
       const store = new JSONStore<{
-        data: { a: BigNumber; b: { c: BigNumber } }
-        witness: boolean
-        lockArgs: BigNumber
-        typeArgs: { a: BigNumber }
+        data: { a: string; b: { c: string } }
+        witness: string
+        lockArgs: string
+        typeArgs: { a: string }
       }>({
         data: true,
         witness: true,
@@ -339,10 +332,10 @@ describe('test store', () => {
         typeArgs: true,
       })
       const initValue = {
-        data: { a: BigNumber(20), b: { c: BigNumber(20) } },
-        witness: false,
-        lockArgs: BigNumber(10),
-        typeArgs: { a: BigNumber(30) },
+        data: { a: '20', b: { c: '20' } },
+        witness: '0',
+        lockArgs: '10',
+        typeArgs: { a: '30' },
       }
       const onchainData = store.initOnChain(initValue)
       store.handleCall(
@@ -385,10 +378,10 @@ describe('test store', () => {
 
     describe('test set', () => {
       const store = new JSONStore<{
-        data: { a: BigNumber; b: { c: BigNumber } }
-        witness: boolean
-        lockArgs: BigNumber
-        typeArgs: { a: BigNumber }
+        data: { a: string; b: { c: string } }
+        witness: string
+        lockArgs: string
+        typeArgs: { a: string }
       }>({
         data: true,
         witness: true,
@@ -396,10 +389,10 @@ describe('test store', () => {
         typeArgs: true,
       })
       const initValue = {
-        data: { a: BigNumber(10), b: { c: BigNumber(20) } },
-        witness: false,
-        lockArgs: BigNumber(30),
-        typeArgs: { a: BigNumber(40) },
+        data: { a: '10', b: { c: '20' } },
+        witness: '0',
+        lockArgs: '30',
+        typeArgs: { a: '40' },
       }
       const onchainData = store.initOnChain(initValue)
       store.handleCall(
@@ -412,56 +405,56 @@ describe('test store', () => {
       )
       it('set success without path', () => {
         const changedStore = store.set(defaultOutpointString, {
-          data: { a: BigNumber(1), b: { c: BigNumber(2) } },
-          witness: true,
-          lockArgs: BigNumber(3),
-          typeArgs: { a: BigNumber(4) },
+          data: { a: '1', b: { c: '2' } },
+          witness: '1',
+          lockArgs: '3',
+          typeArgs: { a: '4' },
         })
         expect(changedStore.get(defaultOutpointString)).toStrictEqual({
-          data: { a: BigNumber(1), b: { c: BigNumber(2) } },
-          witness: true,
-          lockArgs: BigNumber(3),
-          typeArgs: { a: BigNumber(4) },
+          data: { a: '1', b: { c: '2' } },
+          witness: '1',
+          lockArgs: '3',
+          typeArgs: { a: '4' },
         })
       })
       it('set success without path and no exist on chain', () => {
         expect(() =>
           store.set('0x1234', {
-            data: { a: BigNumber(1), b: { c: BigNumber(2) } },
-            witness: true,
-            lockArgs: BigNumber(3),
-            typeArgs: { a: BigNumber(4) },
+            data: { a: '1', b: { c: '2' } },
+            witness: '1',
+            lockArgs: '3',
+            typeArgs: { a: '4' },
           }),
         ).toThrow(new NonExistentException('0x1234'))
       })
       it('set success with data path', () => {
-        const changedStore = store.set(defaultOutpointString, ['data'], { a: BigNumber(2), b: { c: BigNumber(1) } })
+        const changedStore = store.set(defaultOutpointString, ['data'], { a: '2', b: { c: '1' } })
         expect(changedStore.get(defaultOutpointString, ['data'])).toStrictEqual({
-          a: BigNumber(2),
-          b: { c: BigNumber(1) },
+          a: '2',
+          b: { c: '1' },
         })
       })
       it('set success with data inner path', () => {
-        const changedStore = store.set(defaultOutpointString, ['data', 'b'], { c: BigNumber(1) })
-        expect(changedStore.get(defaultOutpointString, ['data', 'b'])).toStrictEqual({ c: BigNumber(1) })
+        const changedStore = store.set(defaultOutpointString, ['data', 'b'], { c: '1' })
+        expect(changedStore.get(defaultOutpointString, ['data', 'b'])).toStrictEqual({ c: '1' })
       })
       it('set lock args', () => {
-        const changedStore = store.set(defaultOutpointString, ['lockArgs'], BigNumber(1))
-        expect(changedStore.get(defaultOutpointString, ['lockArgs'])).toStrictEqual(BigNumber(1))
+        const changedStore = store.set(defaultOutpointString, ['lockArgs'], '1')
+        expect(changedStore.get(defaultOutpointString, ['lockArgs'])).toStrictEqual('1')
       })
       it('set type args', () => {
-        const changedStore = store.set(defaultOutpointString, ['typeArgs'], { a: BigNumber(1) })
-        expect(changedStore.get(defaultOutpointString, ['typeArgs'])).toStrictEqual({ a: BigNumber(1) })
+        const changedStore = store.set(defaultOutpointString, ['typeArgs'], { a: '1' })
+        expect(changedStore.get(defaultOutpointString, ['typeArgs'])).toStrictEqual({ a: '1' })
       })
     })
 
     describe('test merge cells data with handle call', () => {
-      const initValue = { data: { a: 'a1', b: BigNumber(10) } }
+      const initValue = { data: { a: 'a1', b: '10' } }
       it('use latest cell', () => {
         class UseLatestStore<R extends StorageSchema<JSONStorageOffChain>> extends JSONStore<R> {
           protected mergeStrategy = new UseLatestStrategy<GetStorageStruct<GetStorageStructByTemplate<R>>>()
         }
-        const useLatestStore = new UseLatestStore<{ data: { a: string; b?: BigNumber } }>({ data: true })
+        const useLatestStore = new UseLatestStore<{ data: { a: string; b?: string } }>({ data: true })
         useLatestStore.handleCall(createUpdateParams({ data: useLatestStore.initOnChain(initValue).data }))
         useLatestStore.handleCall(
           createUpdateParams({
@@ -472,12 +465,12 @@ describe('test store', () => {
         expect(useLatestStore.get()).toStrictEqual({ data: { a: 'a2' } })
       })
       it('last cell not exist', () => {
-        const store = new JSONStore<{ data: { a: string; b?: BigNumber; c?: string[] } }>({ data: true })
+        const store = new JSONStore<{ data: { a: string; b?: string; c?: string[] } }>({ data: true })
         store.handleCall(createUpdateParams({ data: store.initOnChain(initValue).data }))
         expect(store.get()).toStrictEqual(initValue)
       })
       it('last cell exist', () => {
-        const store = new JSONStore<{ data: { a: string; b?: BigNumber; c?: string[] } }>({ data: true })
+        const store = new JSONStore<{ data: { a: string; b?: string; c?: string[] } }>({ data: true })
         store.handleCall(createUpdateParams({ data: store.initOnChain(initValue).data }))
         store.handleCall(
           createUpdateParams({
@@ -485,12 +478,12 @@ describe('test store', () => {
             outPoint: { txHash: `0x01${'0'.repeat(62)}`, index: '0x0' },
           }),
         )
-        expect(store.get()).toStrictEqual({ data: { a: 'a2', b: BigNumber(10) } })
+        expect(store.get()).toStrictEqual({ data: { a: 'a2', b: '10' } })
       })
       it('merge array', () => {
-        const store = new JSONStore<{ data: { a: string; b?: BigNumber; c?: string[] } }>({ data: true })
+        const store = new JSONStore<{ data: { a: string; b?: string; c?: string[] } }>({ data: true })
         store.handleCall(
-          createUpdateParams({ data: store.initOnChain({ data: { a: 'a1', b: BigNumber(10), c: ['1', '2'] } }).data }),
+          createUpdateParams({ data: store.initOnChain({ data: { a: 'a1', b: '10', c: ['1', '2'] } }).data }),
         )
         store.handleCall(
           createUpdateParams({
@@ -498,7 +491,7 @@ describe('test store', () => {
             outPoint: { txHash: `0x01${'0'.repeat(62)}`, index: '0x0' },
           }),
         )
-        expect(store.get()).toStrictEqual({ data: { a: 'a2', b: BigNumber(10), c: ['3', '1', '2'] } })
+        expect(store.get()).toStrictEqual({ data: { a: 'a2', b: '10', c: ['3', '1', '2'] } })
       })
     })
 
@@ -509,55 +502,51 @@ describe('test store', () => {
         class UseLatestStore<R extends StorageSchema<JSONStorageOffChain>> extends JSONStore<R> {
           protected mergeStrategy = new UseLatestStrategy<GetStorageStruct<GetStorageStructByTemplate<R>>>()
         }
-        const useLatestStore = new UseLatestStore<{ data: { a: string; b?: BigNumber } }>({ data: true })
+        const useLatestStore = new UseLatestStore<{ data: { a: string; b?: string } }>({ data: true })
         useLatestStore.handleCall(
-          createUpdateParams({ data: useLatestStore.initOnChain({ data: { a: 'a1', b: BigNumber(1) } }).data }),
+          createUpdateParams({ data: useLatestStore.initOnChain({ data: { a: 'a1', b: '1' } }).data }),
         )
         useLatestStore.handleCall(
           createUpdateParams({ data: useLatestStore.initOnChain({ data: { a: 'a2' } }).data, outPoint: outPointTmp }),
         )
-        const changedStore = useLatestStore.set(['data', 'b'], BigNumber(10))
-        expect(changedStore.get()).toStrictEqual({ data: { a: 'a2', b: BigNumber(10) } })
+        const changedStore = useLatestStore.set(['data', 'b'], '10')
+        expect(changedStore.get()).toStrictEqual({ data: { a: 'a2', b: '10' } })
         // early cell not changed
-        expect(changedStore.get(defaultOutpointString)).toStrictEqual({ data: { a: 'a1', b: BigNumber(1) } })
+        expect(changedStore.get(defaultOutpointString)).toStrictEqual({ data: { a: 'a1', b: '1' } })
         expect(changedStore.getChainData(defaultOutpointString).cell).toStrictEqual(
-          createCell({ data: useLatestStore.initOnChain({ data: { a: 'a1', b: BigNumber(1) } }).data }),
+          createCell({ data: useLatestStore.initOnChain({ data: { a: 'a1', b: '1' } }).data }),
         )
         // changed on the latest cell
-        expect(changedStore.get(outPointTmpString)).toStrictEqual({ data: { a: 'a2', b: BigNumber(10) } })
+        expect(changedStore.get(outPointTmpString)).toStrictEqual({ data: { a: 'a2', b: '10' } })
         expect(changedStore.getChainData(outPointTmpString).cell).toStrictEqual(
           createCell({
-            data: useLatestStore.initOnChain({ data: { a: 'a2', b: BigNumber(10) } }).data,
+            data: useLatestStore.initOnChain({ data: { a: 'a2', b: '10' } }).data,
             outPoint: outPointTmp,
           }),
         )
       })
       it('set merged data with root', () => {
-        const store = new JSONStore<{ data: { a: string; b?: BigNumber; c?: string[] } }>({ data: true })
-        store.handleCall(
-          createUpdateParams({ data: store.initOnChain({ data: { a: 'a1', b: BigNumber(1), c: ['1'] } }).data }),
-        )
+        const store = new JSONStore<{ data: { a: string; b?: string; c?: string[] } }>({ data: true })
+        store.handleCall(createUpdateParams({ data: store.initOnChain({ data: { a: 'a1', b: '1', c: ['1'] } }).data }))
         store.handleCall(
           createUpdateParams({ data: store.initOnChain({ data: { a: 'a2', c: ['2'] } }).data, outPoint: outPointTmp }),
         )
-        const changedStore = store.set({ data: { a: 'a3', b: BigNumber(20), c: ['c1', 'c2'] } })
+        const changedStore = store.set({ data: { a: 'a3', b: '20', c: ['c1', 'c2'] } })
         expect(changedStore.get(outPointTmpString)).toStrictEqual({
-          data: { a: 'a3', b: BigNumber(20), c: ['c1', 'c2'] },
+          data: { a: 'a3', b: '20', c: ['c1', 'c2'] },
         })
         expect(changedStore.get(defaultOutpointString)).toBeUndefined()
       })
       it('set field with type array', () => {
-        const store = new JSONStore<{ data: { a: string; b?: BigNumber; c?: string[] } }>({ data: true })
-        store.handleCall(
-          createUpdateParams({ data: store.initOnChain({ data: { a: 'a1', b: BigNumber(1), c: ['1'] } }).data }),
-        )
+        const store = new JSONStore<{ data: { a: string; b?: string; c?: string[] } }>({ data: true })
+        store.handleCall(createUpdateParams({ data: store.initOnChain({ data: { a: 'a1', b: '1', c: ['1'] } }).data }))
         store.handleCall(
           createUpdateParams({ data: store.initOnChain({ data: { a: 'a2', c: ['2'] } }).data, outPoint: outPointTmp }),
         )
         const changedStore = store.set(['data', 'c'], ['1', '2', '3'])
-        expect(changedStore.get()).toStrictEqual({ data: { a: 'a2', b: BigNumber(1), c: ['1', '2', '3'] } })
+        expect(changedStore.get()).toStrictEqual({ data: { a: 'a2', b: '1', c: ['1', '2', '3'] } })
         expect(changedStore.get(outPointTmpString)).toStrictEqual({ data: { a: 'a2', c: ['1', '2', '3'] } })
-        expect(changedStore.get(defaultOutpointString)).toStrictEqual({ data: { b: BigNumber(1) } })
+        expect(changedStore.get(defaultOutpointString)).toStrictEqual({ data: { b: '1' } })
         expect(changedStore.getChainData(outPointTmpString).cell).toStrictEqual(
           createCell({
             data: store.initOnChain({ data: { a: 'a2', c: ['1', '2', '3'] } }).data,
@@ -566,51 +555,51 @@ describe('test store', () => {
         )
         expect(changedStore.getChainData(defaultOutpointString).cell).toStrictEqual(
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          createCell({ data: store.initOnChain({ data: { b: BigNumber(1) } as any }).data }),
+          createCell({ data: store.initOnChain({ data: { b: '1' } as any }).data }),
         )
       })
       it('set field with type not array', () => {
-        const store = new JSONStore<{ data: { a?: string; b?: BigNumber } }>({ data: true })
-        store.handleCall(createUpdateParams({ data: store.initOnChain({ data: { a: 'a1', b: BigNumber(1) } }).data }))
+        const store = new JSONStore<{ data: { a?: string; b?: string } }>({ data: true })
+        store.handleCall(createUpdateParams({ data: store.initOnChain({ data: { a: 'a1', b: '1' } }).data }))
         store.handleCall(
           createUpdateParams({ data: store.initOnChain({ data: { a: 'a2' } }).data, outPoint: outPointTmp }),
         )
-        const changedStore = store.set(['data', 'b'], BigNumber(10)).set(['data', 'a'], 'a3')
-        expect(changedStore.get()).toStrictEqual({ data: { a: 'a3', b: BigNumber(10) } })
+        const changedStore = store.set(['data', 'b'], '10').set(['data', 'a'], 'a3')
+        expect(changedStore.get()).toStrictEqual({ data: { a: 'a3', b: '10' } })
         expect(changedStore.get(outPointTmpString)).toStrictEqual({ data: { a: 'a3' } })
-        expect(changedStore.get(defaultOutpointString)).toStrictEqual({ data: { b: BigNumber(10) } })
+        expect(changedStore.get(defaultOutpointString)).toStrictEqual({ data: { b: '10' } })
         expect(changedStore.getChainData(outPointTmpString).cell).toStrictEqual(
           createCell({ data: store.initOnChain({ data: { a: 'a3' } }).data, outPoint: outPointTmp }),
         )
         expect(changedStore.getChainData(defaultOutpointString).cell).toStrictEqual(
-          createCell({ data: store.initOnChain({ data: { b: BigNumber(10) } }).data }),
+          createCell({ data: store.initOnChain({ data: { b: '10' } }).data }),
         )
       })
       it('set new field and remove old field', () => {
-        const store = new JSONStore<{ data: { a: BigNumber } }>({ data: true })
-        store.handleCall(createUpdateParams({ data: store.initOnChain({ data: { a: BigNumber(1) } }).data }))
+        const store = new JSONStore<{ data: { a: string } }>({ data: true })
+        store.handleCall(createUpdateParams({ data: store.initOnChain({ data: { a: '1' } }).data }))
         store.handleCall(
-          createUpdateParams({ data: store.initOnChain({ data: { a: BigNumber(10) } }).data, outPoint: outPointTmp }),
+          createUpdateParams({ data: store.initOnChain({ data: { a: '10' } }).data, outPoint: outPointTmp }),
         )
-        const changedStore = store.set(['data', 'a'], BigNumber(10)).set(['data', 'a'], BigNumber(20))
-        expect(changedStore.get()).toStrictEqual({ data: { a: BigNumber(20) } })
-        expect(changedStore.get(outPointTmpString)).toStrictEqual({ data: { a: BigNumber(20) } })
-        expect(changedStore.get(defaultOutpointString)).toStrictEqual({ data: { a: BigNumber(1) } })
+        const changedStore = store.set(['data', 'a'], '10').set(['data', 'a'], '20')
+        expect(changedStore.get()).toStrictEqual({ data: { a: '20' } })
+        expect(changedStore.get(outPointTmpString)).toStrictEqual({ data: { a: '20' } })
+        expect(changedStore.get(defaultOutpointString)).toStrictEqual({ data: { a: '1' } })
         expect(changedStore.getChainData(outPointTmpString).cell).toStrictEqual(
-          createCell({ data: store.initOnChain({ data: { a: BigNumber(20) } }).data, outPoint: outPointTmp }),
+          createCell({ data: store.initOnChain({ data: { a: '20' } }).data, outPoint: outPointTmp }),
         )
         expect(changedStore.getChainData(defaultOutpointString).cell).toStrictEqual(
-          createCell({ data: store.initOnChain({ data: { a: BigNumber(1) } }).data }),
+          createCell({ data: store.initOnChain({ data: { a: '1' } }).data }),
         )
       })
       it('throw exception when store has no cell', () => {
-        const store = new JSONStore<{ data: { a: BigNumber } }>({ data: true })
-        expect(() => store.set(['data', 'a'], BigNumber(20))).toThrow(new NoCellToUseException())
+        const store = new JSONStore<{ data: { a: string } }>({ data: true })
+        expect(() => store.set(['data', 'a'], '20')).toThrow(new NoCellToUseException())
       })
       it('throw exception when store has no data', () => {
-        const store = new JSONStore<{ data: { a: BigNumber } }>({ data: true })
-        store.handleCall(createUpdateParams({ data: store.initOnChain({ data: { a: BigNumber(1) } }).data }))
-        expect(() => store.set(['data', 'b', 'c'], BigNumber(20))).toThrow(
+        const store = new JSONStore<{ data: { a: string } }>({ data: true })
+        store.handleCall(createUpdateParams({ data: store.initOnChain({ data: { a: '1' } }).data }))
+        expect(() => store.set(['data', 'b', 'c'], '20')).toThrow(
           new NonExistentException(`${['data', 'b', 'c'].join('.')}`),
         )
       })
@@ -619,14 +608,14 @@ describe('test store', () => {
     describe('test getTxFromDiff', () => {
       const outPointTmp = { txHash: `0x01${'0'.repeat(62)}`, index: '0x0' }
       it('get tx when merge all cells', () => {
-        const store = new JSONStore<{ data: { a: string; b?: BigNumber; c?: string[] } }>({ data: true })
+        const store = new JSONStore<{ data: { a: string; b?: string; c?: string[] } }>({ data: true })
         const updates = [
-          createUpdateParams({ data: store.initOnChain({ data: { a: 'a1', b: BigNumber(1), c: ['1'] } }).data }),
+          createUpdateParams({ data: store.initOnChain({ data: { a: 'a1', b: '1', c: ['1'] } }).data }),
           createUpdateParams({ data: store.initOnChain({ data: { a: 'a2', c: ['2'] } }).data, outPoint: outPointTmp }),
         ]
         store.handleCall(updates[0])
         store.handleCall(updates[1])
-        const changedStore = store.set({ data: { a: 'a3', b: BigNumber(20), c: ['c1', 'c2'] } })
+        const changedStore = store.set({ data: { a: 'a3', b: '20', c: ['c1', 'c2'] } })
         const tx = changedStore.getTxFromDiff(store)
         expect(tx.inputs).toStrictEqual([
           (updates[0].payload.value[0] as UpdateStorageValue).cell,
@@ -634,16 +623,16 @@ describe('test store', () => {
         ])
         const expectedOutput = (updates[1].payload.value[0] as UpdateStorageValue).cell
         expectedOutput.cellOutput.capacity = BI.from('0x16b969d00').add('0x16b969d00').toHexString()
-        expectedOutput.data = store.initOnChain({ data: { a: 'a3', b: BigNumber(20), c: ['c1', 'c2'] } }).data
+        expectedOutput.data = store.initOnChain({ data: { a: 'a3', b: '20', c: ['c1', 'c2'] } }).data
         expect(tx.outputs).toStrictEqual([expectedOutput])
       })
       it('change two of three cells', () => {
-        const store = new JSONStore<{ data: { a: string; b?: BigNumber; c?: { d: string } } }>({ data: true })
+        const store = new JSONStore<{ data: { a: string; b?: string; c?: { d: string } } }>({ data: true })
         const outPointTmp2 = { txHash: `0x02${'0'.repeat(62)}`, index: '0x0' }
         const updates = [
           createUpdateParams({ data: store.initOnChain({ data: { a: 'a1', c: { d: 'd1' } } }).data }),
           createUpdateParams({
-            data: store.initOnChain({ data: { a: 'a2', b: BigNumber(1) } }).data,
+            data: store.initOnChain({ data: { a: 'a2', b: '1' } }).data,
             outPoint: outPointTmp,
           }),
           createUpdateParams({ data: store.initOnChain({ data: { a: 'a2' } }).data, outPoint: outPointTmp2 }),
@@ -651,7 +640,7 @@ describe('test store', () => {
         store.handleCall(updates[0])
         store.handleCall(updates[1])
         store.handleCall(updates[2])
-        const changedStore = store.set(['data', 'b'], BigNumber(20)).set(['data', 'c', 'd'], 'd2')
+        const changedStore = store.set(['data', 'b'], '20').set(['data', 'c', 'd'], 'd2')
         const tx = changedStore.getTxFromDiff(store)
         expect(tx.inputs).toStrictEqual([
           (updates[1].payload.value[0] as UpdateStorageValue).cell,
@@ -663,7 +652,7 @@ describe('test store', () => {
         ]
         expect(tx.outputs[0].cellOutput).toStrictEqual(expectedOutput[0].cell.cellOutput)
         expect(tx.outputs[1].cellOutput).toStrictEqual(expectedOutput[1].cell.cellOutput)
-        expect(expectedOutput[0].cell.data).toBe(changedStore.initOnChain({ data: { a: 'a2', b: BigNumber(20) } }).data)
+        expect(expectedOutput[0].cell.data).toBe(changedStore.initOnChain({ data: { a: 'a2', b: '20' } }).data)
         expect(expectedOutput[1].cell.data).toStrictEqual(
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           changedStore.initOnChain({ data: { c: { d: 'd2' } } as any }).data,
@@ -788,30 +777,30 @@ describe('test store', () => {
 
     describe('test handleCall with add', () => {
       it('add data success', () => {
-        const store = new JSONStore<{ data: { a: BigNumber } }>({ data: true })
-        const initValue = { a: BigNumber(1) }
+        const store = new JSONStore<{ data: { a: string } }>({ data: true })
+        const initValue = { a: '1' }
         const onchainData = store.initOnChain({ data: initValue })
         store.handleCall(createUpdateParams({ data: onchainData.data }))
         expect(store.get(defaultOutpointString)).toStrictEqual({ data: initValue })
       })
       it('add witness success', () => {
-        const store = new JSONStore<{ witness: { a: BigNumber } }>({ witness: true })
-        const initValue = { a: BigNumber(1) }
+        const store = new JSONStore<{ witness: { a: string } }>({ witness: true })
+        const initValue = { a: '1' }
         const onchainData = store.initOnChain({ witness: initValue })
         store.handleCall(createUpdateParams({ witness: onchainData.witness }))
         expect(store.get(defaultOutpointString)).toStrictEqual({ witness: initValue })
       })
       it('add with duplicate add params', () => {
-        const store = new JSONStore<{ data: { a: BigNumber } }>({ data: true })
-        store.handleCall(createUpdateParams({ data: store.initOnChain({ data: { a: BigNumber(1) } }).data }))
-        const initValue = { a: BigNumber(10) }
+        const store = new JSONStore<{ data: { a: string } }>({ data: true })
+        store.handleCall(createUpdateParams({ data: store.initOnChain({ data: { a: '1' } }).data }))
+        const initValue = { a: '10' }
         const onchainData = store.initOnChain({ data: initValue })
         store.handleCall(createUpdateParams({ data: onchainData.data }))
         expect(store.get(defaultOutpointString)).toStrictEqual({ data: initValue })
       })
       it('add lock without offset', () => {
-        const lockStore = new JSONStore<{ lockArgs: BigNumber }>({ lockArgs: true })
-        const initValue = { lockArgs: BigNumber(1) }
+        const lockStore = new JSONStore<{ lockArgs: string }>({ lockArgs: true })
+        const initValue = { lockArgs: '1' }
         const onchainData = lockStore.initOnChain(initValue)
         lockStore.handleCall(
           createUpdateParams({ lock: { args: onchainData.lockArgs, codeHash: '', hashType: 'data' } }),
@@ -819,10 +808,10 @@ describe('test store', () => {
         expect(lockStore.get(defaultOutpointString)).toStrictEqual(initValue)
       })
       it('add lock with offset', () => {
-        const lockStore = new JSONStore<{ lockArgs: { offset: 10; schema: BigNumber } }>({
+        const lockStore = new JSONStore<{ lockArgs: { offset: 10; schema: string } }>({
           lockArgs: { offset: 10 },
         })
-        const initValue = { lockArgs: BigNumber(10) }
+        const initValue = { lockArgs: '10' }
         const onchainData = lockStore.initOnChain(initValue)
         lockStore.handleCall(
           createUpdateParams({ lock: { args: onchainData.lockArgs, codeHash: '', hashType: 'data' } }),
@@ -830,17 +819,17 @@ describe('test store', () => {
         expect(lockStore.get(defaultOutpointString)).toStrictEqual(initValue)
       })
       it('add type without offset', () => {
-        const store = new JSONStore<{ typeArgs: BigNumber }>({ typeArgs: true })
-        const initValue = { typeArgs: BigNumber(1) }
+        const store = new JSONStore<{ typeArgs: string }>({ typeArgs: true })
+        const initValue = { typeArgs: '1' }
         const onchainData = store.initOnChain(initValue)
         store.handleCall(createUpdateParams({ type: { args: onchainData.typeArgs, codeHash: '', hashType: 'data' } }))
         expect(store.get(defaultOutpointString)).toStrictEqual(initValue)
       })
       it('add type with offset', () => {
-        const store = new JSONStore<{ typeArgs: { offset: 10; schema: BigNumber } }>({
+        const store = new JSONStore<{ typeArgs: { offset: 10; schema: string } }>({
           typeArgs: { offset: 10 },
         })
-        const initValue = { typeArgs: BigNumber(10) }
+        const initValue = { typeArgs: '10' }
         const onchainData = store.initOnChain(initValue)
         store.handleCall(createUpdateParams({ type: { args: onchainData.typeArgs, codeHash: '', hashType: 'data' } }))
         expect(store.get(defaultOutpointString)).toStrictEqual(initValue)

--- a/packages/models/__tests__/utils/helper.ts
+++ b/packages/models/__tests__/utils/helper.ts
@@ -1,5 +1,4 @@
 import { describe, it, expect, jest, beforeEach } from '@jest/globals'
-import BigNumber from 'bignumber.js'
 import { BI } from '@ckb-lumos/bi'
 import { deepForIn } from '../../src'
 
@@ -25,12 +24,6 @@ describe('test deep for in', () => {
     expect(callBack).toBeCalledWith(true, [])
     expect(callBack).toBeCalledTimes(3)
   })
-  it('call break when callback Return false with BigNumber', () => {
-    callBack.mockReturnValue(false)
-    deepForIn(BigNumber(10), callBack)
-    expect(callBack).toBeCalledWith(BigNumber(10), [])
-    expect(callBack).toBeCalledTimes(1)
-  })
   it('call break when callback Return false with BI', () => {
     callBack.mockReturnValue(false)
     deepForIn(BI.from(10), callBack)
@@ -38,11 +31,10 @@ describe('test deep for in', () => {
     expect(callBack).toBeCalledTimes(1)
   })
   it('call with object', () => {
-    callBack.mockImplementation((v) => (v instanceof BigNumber ? false : true))
-    deepForIn({ a: BigNumber(10), b: 'b1' }, callBack)
-    expect(callBack).toBeCalledWith({ a: BigNumber(10), b: 'b1' }, [])
-    expect(callBack).toBeCalledWith(BigNumber(10), ['a'])
+    callBack.mockImplementation((_v) => true)
+    deepForIn({ b: 'b1' }, callBack)
+    expect(callBack).toBeCalledWith({ b: 'b1' }, [])
     expect(callBack).toBeCalledWith('b1', ['b'])
-    expect(callBack).toBeCalledTimes(3)
+    expect(callBack).toBeCalledTimes(2)
   })
 })

--- a/packages/models/package.json
+++ b/packages/models/package.json
@@ -34,7 +34,6 @@
     "@ckb-lumos/base": "0.19.0",
     "@ckb-lumos/codec": "0.19.0",
     "@ckb-lumos/experiment-tx-assembler": "0.19.0",
-    "bignumber.js": "9.1.1",
     "inversify": "6.0.1",
     "ioredis": "5.3.2",
     "lodash": "4.17.21",

--- a/packages/models/src/exceptions/store.ts
+++ b/packages/models/src/exceptions/store.ts
@@ -10,18 +10,6 @@ export class NonStorageInstanceException extends Error {
   }
 }
 
-export class UnexpectedTypeException extends Error {
-  constructor(type: string) {
-    super(`Unexpected type: ${type} in storage`)
-  }
-}
-
-export class UnexpectedMarkException extends Error {
-  constructor(mark: string) {
-    super(`Unexpected mark: ${mark} in storage`)
-  }
-}
-
 export class UnexpectedParamsException extends Error {
   constructor(params: string) {
     super(`Unexpected params with ${params} when calling deserialize`)

--- a/packages/models/src/store/json-storage.ts
+++ b/packages/models/src/store/json-storage.ts
@@ -18,7 +18,7 @@ const TYPE_MARK_MAP = {
   [BIG_NUMBER_TYPE]: '2',
 }
 
-function reviver(key: string, value: JSONStorageOffChain | JSONStorageType) {
+export function reviver(key: string, value: JSONStorageOffChain | JSONStorageType) {
   if (value === null) throw new UnexpectedTypeException('null')
   if (typeof value === 'object') {
     return value
@@ -68,13 +68,13 @@ export function addMarkForStorage(data?: JSONStorageOffChain): AddMarkStorage {
 
 export class JSONStorage<T extends JSONStorageOffChain> extends ChainStorage<T> {
   serialize(data: T): Uint8Array {
-    return Buffer.from(JSON.stringify(addMarkForStorage(data)))
+    return Buffer.from(JSON.stringify(data))
   }
 
   deserialize(data: Uint8Array): T {
     if (data === null || data === undefined) throw new UnexpectedParamsException(`${data}`)
     const json = Buffer.from(data).toString()
     if (json === '') throw new UnexpectedParamsException(`${data}`)
-    return JSON.parse(Buffer.from(data).toString(), reviver)
+    return JSON.parse(Buffer.from(data).toString())
   }
 }

--- a/packages/models/src/store/json-storage.ts
+++ b/packages/models/src/store/json-storage.ts
@@ -1,70 +1,13 @@
-import BigNumber from 'bignumber.js'
-import { UnexpectedMarkException, UnexpectedParamsException, UnexpectedTypeException } from '../exceptions'
+import { UnexpectedParamsException } from '../exceptions'
 import { ChainStorage } from './chain-storage'
 
-export type JSONStorageType = string | boolean | BigNumber
+export type JSONStorageType = string
 export type JSONStorageOffChain =
   | JSONStorageType
   | JSONStorageOffChain[]
   | {
       [x: string]: JSONStorageOffChain
     }
-
-const TYPE_MARK_LEN = 1
-const BIG_NUMBER_TYPE = 'bignumber'
-const TYPE_MARK_MAP = {
-  string: '0',
-  boolean: '1',
-  [BIG_NUMBER_TYPE]: '2',
-}
-
-export function reviver(key: string, value: JSONStorageOffChain | JSONStorageType) {
-  if (value === null) throw new UnexpectedTypeException('null')
-  if (typeof value === 'object') {
-    return value
-  }
-  const mark = value.toString().slice(0, TYPE_MARK_LEN)
-  if (mark.length !== TYPE_MARK_LEN) {
-    throw new UnexpectedMarkException(mark)
-  }
-  const acturalValue = value.toString().slice(TYPE_MARK_LEN)
-  switch (mark) {
-    case TYPE_MARK_MAP['string']:
-      return acturalValue
-    case TYPE_MARK_MAP['boolean']:
-      return acturalValue === 'true'
-    case TYPE_MARK_MAP['bignumber']:
-      return BigNumber(acturalValue)
-    default:
-      throw new UnexpectedMarkException(mark)
-  }
-}
-
-function serializeSimpleType(v: string | boolean) {
-  const valueType = typeof v
-  if (v === null) throw new UnexpectedTypeException('null')
-  const mark = TYPE_MARK_MAP[valueType as keyof typeof TYPE_MARK_MAP]
-  if (mark) {
-    return `${mark}${v.toString()}`
-  }
-  throw new UnexpectedTypeException(valueType)
-}
-
-type AddMarkStorage = string | AddMarkStorage[] | { [key: string]: AddMarkStorage }
-
-export function addMarkForStorage(data?: JSONStorageOffChain): AddMarkStorage {
-  if (data === null || data === undefined) throw new UnexpectedTypeException(`${data}`)
-  if (data instanceof BigNumber) return `${TYPE_MARK_MAP[BIG_NUMBER_TYPE]}${data.toFixed()}`
-  if (typeof data !== 'object') return serializeSimpleType(data)
-  if (Array.isArray(data)) {
-    return data.map((v) => addMarkForStorage(v))
-  }
-  const newData: Record<string, AddMarkStorage> = {}
-  Object.keys(data).forEach((key: string) => {
-    newData[key] = addMarkForStorage(data[key])
-  })
-  return newData
-}
 
 export class JSONStorage<T extends JSONStorageOffChain> extends ChainStorage<T> {
   serialize(data: T): Uint8Array {

--- a/packages/models/src/store/merge-strategy.ts
+++ b/packages/models/src/store/merge-strategy.ts
@@ -1,6 +1,5 @@
 import { get, mergeWith, set } from 'lodash/fp'
 import { BI } from '@ckb-lumos/bi'
-import BigNumber from 'bignumber.js'
 import { CantSetValueInSimpleType, NoCellToUseException, NonExistentException } from '../exceptions'
 import { deepForIn } from '../utils'
 import type { OutPointString } from './interface'
@@ -29,17 +28,13 @@ export abstract class MergeStrategy<S, T = S> {
       vType === 'number' ||
       vType === 'undefined' ||
       vType === null ||
-      value instanceof BI ||
-      value instanceof BigNumber
+      value instanceof BI
     )
   }
 
   isValueEqual(value: unknown, compare: unknown): boolean {
     if (this.isSimpleType(value) && this.isSimpleType(compare)) {
       if (value instanceof BI && compare instanceof BI) {
-        return value.eq(compare)
-      }
-      if (value instanceof BigNumber && compare instanceof BigNumber) {
         return value.eq(compare)
       }
       return value === compare

--- a/packages/models/src/store/store.ts
+++ b/packages/models/src/store/store.ts
@@ -103,7 +103,7 @@ export class Store<
     this.options = params?.options
 
     this.initiateLock(params?.ref)
-    this.#type = Reflect.getMetadata(ProviderKey.TypePattern, this.constructor)
+    this.initiateType(params?.ref)
 
     const cellPatternFactorys = Reflect.getMetadata(ProviderKey.CellPattern, this.constructor)
     this.cellPatterns =
@@ -111,7 +111,7 @@ export class Store<
       (cellPatternFactorys
         ? // eslint-disable-next-line @typescript-eslint/no-explicit-any
           cellPatternFactorys.map((factory: (...args: any[]) => CellPattern) =>
-            factory({ lockScript: this.lockScript }),
+            factory({ lockScript: this.lockScript, typeScript: this.typeScript }),
           )
         : [])
   }
@@ -119,6 +119,15 @@ export class Store<
   private initiateLock(ref?: ActorRef) {
     const createLock = Reflect.getMetadata(ProviderKey.LockPattern, this.constructor)
     if (typeof createLock == 'function') this.#lock = createLock(ref)
+  }
+
+  private initiateType(ref?: ActorRef) {
+    const typePattern = Reflect.getMetadata(ProviderKey.TypePattern, this.constructor)
+    if (typeof typePattern == 'function') {
+      this.#type = typePattern(ref)
+    } else {
+      this.#type = typePattern
+    }
   }
 
   protected registerResourceBinding() {

--- a/packages/models/src/utils/decorator/provider.ts
+++ b/packages/models/src/utils/decorator/provider.ts
@@ -87,6 +87,15 @@ export const LockPattern = (): ClassDecorator =>
       value.cell.cellOutput.lock.hashType === obj.lockScript.hashType,
   })
 
+// FIXME: refactor with LockPattern
+export const TypePattern = (): ClassDecorator =>
+  Pattern({
+    cellPattern: (obj: { typeScript: Script }) => (value: UpdateStorageValue) =>
+      value.cell.cellOutput.type?.args === obj.typeScript.args &&
+      value.cell.cellOutput.type?.codeHash === obj.typeScript.codeHash &&
+      value.cell.cellOutput.type?.hashType === obj.typeScript.hashType,
+  })
+
 export const DataPattern = (data: string): ClassDecorator =>
   Pattern({ cellPattern: () => (value: UpdateStorageValue) => value.cell.data == data })
 
@@ -98,6 +107,21 @@ export const Lock =
   (target: object) =>
     Reflect.defineMetadata(
       ProviderKey.LockPattern,
+      (ref?: ActorRef) => {
+        const codeHash = script?.codeHash ?? ref?.params?.codeHash
+        const hashType = script?.hashType ?? ref?.params?.hashType
+        const args = script?.args ?? ref?.params?.args ?? '0x'
+        return codeHash && hashType ? { codeHash, hashType, args } : undefined
+      },
+      target,
+    )
+
+// FIXME: refactor with Lock
+export const Type =
+  (script?: Partial<Script>): ClassDecorator =>
+  (target: object) =>
+    Reflect.defineMetadata(
+      ProviderKey.TypePattern,
       (ref?: ActorRef) => {
         const codeHash = script?.codeHash ?? ref?.params?.codeHash
         const hashType = script?.hashType ?? ref?.params?.hashType

--- a/packages/samples/mvp-dapp/README.md
+++ b/packages/samples/mvp-dapp/README.md
@@ -117,6 +117,16 @@ It's quite similar to the [setState](https://reactjs.org/docs/faq-state.html#wha
 
 Follow the [Guide](../../../README.md) to build libraries developed in other workspaces.
 
+### Get Contract Ready
+
+#### Deploy your own contract
+
+Follow https://github.com/ckb-js/kuai/issues/306 to deploy your own contract. Or
+
+#### Connect to the demo contract deployed on the Testnet
+
+The deployment information located at `mvp-dapp/contract/deployed_demo`, rename it to `mvp-dapp/contract/deployed` to connect to
+
 ### Build the mvp dapp
 
 ```sh

--- a/packages/samples/mvp-dapp/contract/.gitignore
+++ b/packages/samples/mvp-dapp/contract/.gitignore
@@ -40,3 +40,5 @@ byzantine/tests/node_modules
 
 node_modules/*
 build/*
+deployed
+

--- a/packages/samples/mvp-dapp/contract/deployed_demo/contracts.json
+++ b/packages/samples/mvp-dapp/contract/deployed_demo/contracts.json
@@ -1,0 +1,14 @@
+{
+  "kuai-mvp-contract": {
+    "depType": "code",
+    "outPoint": {
+      "txHash": "0x005a153ec6a35adbc8d82544ae11d8c6f8c0601fc9059f8a872e01f638fc9f62",
+      "index": "0x0"
+    },
+    "script": {
+      "codeHash": "0x1a3de2a61b454e8492a775cf438748e362e71930170bec90c4e6b79e4dd7ea3c",
+      "hashType": "type",
+      "args": "0x"
+    }
+  }
+}

--- a/packages/samples/mvp-dapp/src/actors/omnilock.model.ts
+++ b/packages/samples/mvp-dapp/src/actors/omnilock.model.ts
@@ -4,6 +4,7 @@
  * This is the actor model for omnilock, which is used to gather omnilock cells to generate record models.
  */
 
+import type { Cell, HexString } from '@ckb-lumos/base'
 import {
   ActorProvider,
   Omnilock,
@@ -16,11 +17,13 @@ import {
   UpdateStorageValue,
   DataPattern,
   LockPattern,
+  JSONStorage,
 } from '@ckb-js/kuai-models'
-import { Cell, HexString } from '@ckb-lumos/base'
 import { BI } from '@ckb-lumos/bi'
+import { helpers } from '@ckb-lumos/lumos'
 import { InternalServerError } from 'http-errors'
-import { DAPP_DATA_PREFIX, INITIAL_RECORD_STATE, TX_FEE } from '../const'
+import { DAPP_DATA_PREFIX, TX_FEE, MVP_CONTRACT_TYPE_SCRIPT } from '../const'
+import { bytes } from '@ckb-lumos/codec'
 
 /**
  * add business logic in an actor
@@ -30,6 +33,8 @@ import { DAPP_DATA_PREFIX, INITIAL_RECORD_STATE, TX_FEE } from '../const'
 @DataPattern('0x')
 @Omnilock()
 export class OmnilockModel extends JSONStore<Record<string, never>> {
+  #omnilockAddress: string
+
   constructor(
     @Param('args') args: string,
     _schemaOption?: void,
@@ -45,6 +50,7 @@ export class OmnilockModel extends JSONStore<Record<string, never>> {
       throw new Error('lock script is required')
     }
     this.registerResourceBinding()
+    this.#omnilockAddress = helpers.encodeToAddress(this.lockScript)
   }
 
   get meta(): Record<'capacity', string> {
@@ -70,6 +76,11 @@ export class OmnilockModel extends JSONStore<Record<string, never>> {
       return true
     })
     if (currentTotalCapacity.lt(needCapacity)) throw new InternalServerError('not enough capacity')
+
+    const INITIAL_RECORD_STATE = bytes
+      .hexify(new JSONStorage().serialize({ addresses: [{ key: 'ckb', value: this.#omnilockAddress }] }))
+      .slice(2)
+
     return {
       inputs: inputs.map((v) => v.cell),
       outputs: [
@@ -77,6 +88,7 @@ export class OmnilockModel extends JSONStore<Record<string, never>> {
           cellOutput: {
             // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
             lock: this.lockScript!,
+            type: MVP_CONTRACT_TYPE_SCRIPT,
             capacity,
           },
           data: `${DAPP_DATA_PREFIX}${INITIAL_RECORD_STATE}`,

--- a/packages/samples/mvp-dapp/src/actors/omnilock.model.ts
+++ b/packages/samples/mvp-dapp/src/actors/omnilock.model.ts
@@ -78,7 +78,9 @@ export class OmnilockModel extends JSONStore<Record<string, never>> {
     if (currentTotalCapacity.lt(needCapacity)) throw new InternalServerError('not enough capacity')
 
     const INITIAL_RECORD_STATE = bytes
-      .hexify(new JSONStorage().serialize({ addresses: [{ key: 'ckb', value: this.#omnilockAddress }] }))
+      .hexify(
+        new JSONStorage().serialize({ addresses: [{ key: 'ckb', value: this.#omnilockAddress, label: 'required' }] }),
+      )
       .slice(2)
 
     return {

--- a/packages/samples/mvp-dapp/src/actors/record.model.ts
+++ b/packages/samples/mvp-dapp/src/actors/record.model.ts
@@ -4,9 +4,11 @@
  * This is the actor model for record, which is used to store data in a json format.
  */
 
+import type { Cell } from '@ckb-lumos/base'
 import {
   ActorProvider,
   Lock,
+  Type,
   Param,
   ActorReference,
   CellPattern,
@@ -14,13 +16,12 @@ import {
   OutPointString,
   SchemaPattern,
   UpdateStorageValue,
-  DataPrefixPattern,
   LockPattern,
+  TypePattern,
 } from '@ckb-js/kuai-models'
-import { Cell } from '@ckb-lumos/base'
 import { InternalServerError } from 'http-errors'
 import { BI } from '@ckb-lumos/bi'
-import { DAPP_DATA_PREFIX, DAPP_DATA_PREFIX_LEN, TX_FEE } from '../const'
+import { DAPP_DATA_PREFIX_LEN, MVP_CONTRACT_TYPE_SCRIPT, TX_FEE } from '../const'
 
 export type ItemData = {
   key: string
@@ -42,8 +43,9 @@ export type StoreType = {
  */
 @ActorProvider({ ref: { name: 'record', path: '/:codeHash/:hashType/:args/' } })
 @LockPattern()
-@DataPrefixPattern(DAPP_DATA_PREFIX)
+@TypePattern()
 @Lock()
+@Type(MVP_CONTRACT_TYPE_SCRIPT)
 export class RecordModel extends JSONStore<{ data: { offset: number; schema: StoreType['data'] } }> {
   constructor(
     @Param('codeHash') codeHash: string,
@@ -112,12 +114,17 @@ export class RecordModel extends JSONStore<{ data: { offset: number; schema: Sto
           cellOutput: {
             ...v.cell.cellOutput,
             capacity: BI.from(v.cell.cellOutput.capacity).sub(TX_FEE).toHexString(),
+            type: undefined,
           },
           data: '0x',
         }
       }
       return {
         ...v.cell,
+        cellOutput: {
+          ...v.cell.cellOutput,
+          type: undefined,
+        },
         data: '0x',
       }
     })

--- a/packages/samples/mvp-dapp/src/app.controller.ts
+++ b/packages/samples/mvp-dapp/src/app.controller.ts
@@ -44,7 +44,7 @@ router.post<never, { address: string }, { capacity: HexString }>('/claim/:addres
     new ActorReference('omnilock', `/${getLock(params?.address).args}/`),
   )
   const result = omniLockModel.claim(body.capacity)
-  ctx.ok(MvpResponse.ok(Tx.toJsonString(result)))
+  ctx.ok(MvpResponse.ok(await Tx.toJsonString(result)))
 })
 
 router.get<never, { path: string; address: string }>('/load/:address/:path', async (ctx) => {
@@ -84,7 +84,7 @@ router.post<never, { address: string }, { value: StoreType['data'] }>('/set/:add
     new ActorReference('record', `/${lock.codeHash}/${lock.hashType}/${lock.args}/`),
   )
   const result = recordModel.update(ctx.payload.body.value)
-  ctx.ok(MvpResponse.ok(Tx.toJsonString(result)))
+  ctx.ok(MvpResponse.ok(await Tx.toJsonString(result)))
 })
 
 router.post<never, { address: string }>('/clear/:address', async (ctx) => {

--- a/packages/samples/mvp-dapp/src/const.ts
+++ b/packages/samples/mvp-dapp/src/const.ts
@@ -4,12 +4,28 @@
  * This module defines the constants used in the application.
  */
 
+import type { Script, CellDep } from '@ckb-lumos/base'
 import { bytes } from '@ckb-lumos/codec'
+import { getDeployedContracts } from './utils'
+import { MvpError } from './exception'
 
 export const DAPP_DATA_PREFIX = bytes.hexify(Buffer.from('mvp-dapp'))
 
 export const DAPP_DATA_PREFIX_LEN = DAPP_DATA_PREFIX.length
 
-export const INITIAL_RECORD_STATE = Buffer.from('{}').toString('hex')
-
 export const TX_FEE = 100000
+
+// runtime constants
+const deployedContracts = getDeployedContracts()
+const mvpContract = deployedContracts['kuai-mvp-contract']
+
+if (!mvpContract) {
+  throw new MvpError('MVP contract is not found', '404')
+}
+
+export const MVP_CONTRACT_TYPE_SCRIPT: Script = mvpContract.script
+
+export const MVP_CONTRACT_CELL_DEP: CellDep = {
+  outPoint: mvpContract.outPoint,
+  depType: mvpContract.depType,
+}

--- a/packages/samples/mvp-dapp/src/utils/index.ts
+++ b/packages/samples/mvp-dapp/src/utils/index.ts
@@ -1,0 +1,22 @@
+import { join } from 'node:path'
+import { existsSync, readFileSync } from 'node:fs'
+import { MvpError } from '../exception'
+
+/**
+ * This method is used to get deployed transactions of the contract module,
+ * and will be obsolete once these information are injected by kuai framework
+ */
+export const getDeployedContracts = () => {
+  const PATH = join('contract', 'deployed', 'contracts.json')
+  if (!existsSync(PATH)) {
+    throw new MvpError(`${PATH}, please deploy contracts first`, '500')
+  }
+
+  try {
+    const data = readFileSync(PATH, 'utf8')
+    const deployed = JSON.parse(data)
+    return deployed
+  } catch {
+    throw new MvpError(`Failed to load ${PATH}, please check the file format`, '500')
+  }
+}

--- a/packages/samples/mvp-dapp/src/utils/index.ts
+++ b/packages/samples/mvp-dapp/src/utils/index.ts
@@ -7,7 +7,8 @@ import { MvpError } from '../exception'
  * and will be obsolete once these information are injected by kuai framework
  */
 export const getDeployedContracts = () => {
-  const PATH = join('contract', 'deployed', 'contracts.json')
+  const DIR_NAME = process.env.NODE_ENV === 'test' ? 'deployed_demo' : 'deployed'
+  const PATH = join('contract', DIR_NAME, 'contracts.json')
   if (!existsSync(PATH)) {
     throw new MvpError(`${PATH}, please deploy contracts first`, '500')
   }

--- a/packages/samples/mvp-dapp/src/views/tx.view.ts
+++ b/packages/samples/mvp-dapp/src/views/tx.view.ts
@@ -1,13 +1,8 @@
-/**
- * @module src/views/tx.view
- * @description
- * This module works as the view layer and is used to generate transaction skeleton.
- */
-
-import { Cell, helpers, config } from '@ckb-lumos/lumos'
+import { type Cell, helpers, config } from '@ckb-lumos/lumos'
 import { SECP_SIGNATURE_PLACEHOLDER, OMNILOCK_SIGNATURE_PLACEHOLDER } from '@ckb-lumos/common-scripts/lib/helper'
 import { blockchain } from '@ckb-lumos/base'
 import { bytes } from '@ckb-lumos/codec'
+import { MVP_CONTRACT_CELL_DEP } from '../const'
 
 export class Tx {
   static async toJsonString({
@@ -22,8 +17,9 @@ export class Tx {
     let txSkeleton = helpers.TransactionSkeleton({})
     txSkeleton = txSkeleton.update('outputs', (v) => v.push(...outputs))
     const CONFIG = config.getConfig()
-    txSkeleton = txSkeleton.update('cellDeps', (cellDeps) =>
-      cellDeps.push(
+    txSkeleton = txSkeleton.update('cellDeps', (v) =>
+      v.push(
+        MVP_CONTRACT_CELL_DEP,
         {
           outPoint: {
             txHash: CONFIG.SCRIPTS.OMNILOCK!.TX_HASH,


### PR DESCRIPTION
Most codes are copied from @yanguoyu's work at https://github.com/ckb-js/kuai/pull/305/commits/2d9150845b3d3371fa141d0d937c791b672fb9a1

A convention is introduced in this PR that deployment info of the contract module should be located at `contract/deployed/`(contract/deployed_demo in this case for demonstration). It's updated manually in this demo, but should be generated automatically in the future.

---

Demo preview
https://www.youtube.com/watch?v=-R3EQxcWJVU