### PR TITLE
feat: add contract upgrade cli

### DIFF
--- a/packages/core/src/builtin-tasks/contract.ts
+++ b/packages/core/src/builtin-tasks/contract.ts
@@ -31,7 +31,6 @@ interface ContractDeployArgs {
   export?: string
   migrationDir?: string
   noTypeId: boolean
-  send: boolean
 }
 
 function isMultisigFromInfo(fromInfo: FromInfo): fromInfo is MultisigScript {
@@ -90,11 +89,10 @@ subtask('contract:deploy')
     true,
   )
   .addParam('export', 'export transaction to file', '', paramTypes.path, true)
-  .addParam('send', 'send transaction directly', false, paramTypes.boolean, true)
   .addParam('no-type-id', 'not use type id deploy', false, paramTypes.boolean, true)
   .addParam('migration-dir', 'migration directory for saving json format migration files', '', paramTypes.path, true)
   .setAction(async (args: ContractDeployArgs, { config, run }) => {
-    const { name, from, feeRate, signer, binPath, noTypeId = false, send = false, migrationDir } = args
+    const { name, from, feeRate, signer, binPath, noTypeId = false, migrationDir } = args
     const { ckbChain } = config
 
     const fromInfos = parseFromInfoByCli(from)
@@ -190,9 +188,7 @@ subtask('contract:deploy')
       })
 
       writeFileSync(exportPath, JSON.stringify(exportData, null, 2))
-    }
-
-    if (send) {
+    } else {
       const txHash = await sendTx()
       console.info('deploy success, txHash: ', txHash)
       if (migrationDir) {
@@ -231,7 +227,6 @@ interface ContractUpgradeArgs {
   deployer?: string[]
   feeRate?: number
   export?: string
-  send: boolean
 }
 subtask('contract:upgrade')
   .addParam('name', 'name of the contract to upgrade', '', paramTypes.string, true)
@@ -262,9 +257,8 @@ subtask('contract:upgrade')
     true,
   )
   .addParam('export', 'export transaction to file', '', paramTypes.path, true)
-  .addParam('send', 'send transaction directly', false, paramTypes.boolean, true)
   .setAction(async (args: ContractUpgradeArgs, { config, run }) => {
-    const { name, feePayer, deployer, feeRate, signer, binPath, send = false, migrationDir } = args
+    const { name, feePayer, deployer, feeRate, signer, binPath, migrationDir } = args
     const { ckbChain } = config
 
     const deployerInfos = deployer ? parseFromInfoByCli(deployer) : []
@@ -388,9 +382,7 @@ subtask('contract:upgrade')
       })
 
       writeFileSync(exportPath, JSON.stringify(exportData, null, 2))
-    }
-
-    if (send) {
+    } else {
       const txHash = await sendTx()
       console.info('deploy success, txHash: ', txHash)
 

--- a/packages/core/src/contract.ts
+++ b/packages/core/src/contract.ts
@@ -1,7 +1,7 @@
 import { readFileSync } from 'node:fs'
 import { Hash, Transaction, blockchain } from '@ckb-lumos/base'
-import { generateDeployWithTypeIdTx } from '@ckb-lumos/common-scripts/lib/deploy'
-import { sealTransaction, createTransactionFromSkeleton } from '@ckb-lumos/helpers'
+import { generateDeployWithTypeIdTx, generateUpgradeTypeIdDataTx } from '@ckb-lumos/common-scripts/lib/deploy'
+import { sealTransaction, createTransactionFromSkeleton, scriptToAddress } from '@ckb-lumos/helpers'
 import { Indexer, commons, config, RPC, utils } from '@ckb-lumos/lumos'
 import type { FromInfo } from '@ckb-lumos/common-scripts'
 
@@ -65,9 +65,13 @@ export class ContractDeployer {
     const tx = await (async () => {
       if (this.#signer) {
         const signerProvider = this.#signer
-        const signatures = await Promise.all(
-          txSkeleton.signingEntries.map(({ message }) => signerProvider(message, fromInfo)),
-        )
+        const signatures: string[] = []
+        for (const { message, index } of txSkeleton.signingEntries) {
+          const signer = scriptToAddress(txSkeleton.inputs.get(index)!.cellOutput.lock, {
+            config: this.#network.config,
+          })
+          signatures.push(await signerProvider(message, signer))
+        }
 
         return sealTransaction(txSkeleton, signatures)
       }
@@ -80,6 +84,73 @@ export class ContractDeployer {
       index: parseInt(scriptConfig.INDEX),
       dataHash: scriptConfig.CODE_HASH,
       typeId: utils.ckbHash(blockchain.Script.pack(typeId)),
+      send: () => this.#rpc.sendTransaction(tx),
+    }
+  }
+
+  async upgrade(
+    contractBinPath: string,
+    deployer: FromInfo,
+    feePayer: FromInfo,
+    contract: {
+      txHash: Hash
+      index: number
+      dataHash: Hash
+    },
+    options?: {
+      feeRate?: number
+    },
+  ): Promise<{
+    tx: Transaction
+    index: number
+    dataHash: string
+    typeId?: string
+    send: () => Promise<Hash>
+  }> {
+    const { feeRate = 1000 } = options || {}
+    const contractBin = readFileSync(contractBinPath)
+
+    const contractTx = await this.#rpc.getTransaction(contract.txHash)
+    const typeIdScript = contractTx.transaction.outputs[contract.index].type!
+
+    const result = await generateUpgradeTypeIdDataTx({
+      cellProvider: this.#index,
+      typeId: typeIdScript,
+      fromInfo: deployer,
+      scriptBinary: contractBin,
+      config: this.#network.config,
+    })
+
+    let { txSkeleton } = result
+    const { scriptConfig } = result
+
+    txSkeleton = await commons.common.payFee(txSkeleton, [feePayer], feeRate, undefined, {
+      config: this.#network.config,
+    })
+    txSkeleton = commons.common.prepareSigningEntries(txSkeleton)
+
+    const tx = await (async () => {
+      if (this.#signer) {
+        const signerProvider = this.#signer
+        const signatures: string[] = []
+        for (const { message, index } of txSkeleton.signingEntries) {
+          const signer = scriptToAddress(txSkeleton.inputs.get(index)!.cellOutput.lock, {
+            config: this.#network.config,
+          })
+          signatures.push(await signerProvider(message, signer))
+        }
+
+        return sealTransaction(txSkeleton, signatures)
+      }
+
+      return createTransactionFromSkeleton(txSkeleton)
+    })()
+
+    return {
+      tx,
+      index: parseInt(scriptConfig.INDEX),
+      dataHash: scriptConfig.CODE_HASH,
+      typeId: utils.ckbHash(blockchain.Script.pack(typeIdScript)),
       send: () => this.#rpc.sendTransaction(tx),
     }
   }

--- a/packages/core/src/errors-list.ts
+++ b/packages/core/src/errors-list.ts
@@ -64,6 +64,14 @@ Please run: npm install --save-dev typescript`,
       code: 'CONTRACT_RELEASE_FILE_NOT_FOUND',
       message: '%var% contract release file not found, please check if conrtact exists or build it first',
     },
+    CONTRACT_MIGRATION_DIRECTORY_NOT_FOUND: {
+      code: 'CONTRACT_MIGRATION_DIRECTORY_NOT_FOUND',
+      message: '%var% contract migration directory not found',
+    },
+    INVALID_CONTRACT_MIGRATION_FILE: {
+      code: 'INVALID_CONTRACT_MIGRATION_FILE',
+      message: '%var% contract migration file invalid',
+    },
     NOT_SPECIFY_CONTRACT: {
       code: 'NOT_SPECIFY_CONTRACT',
       message: 'Please specify the name or path of the contract',

--- a/packages/core/src/util/contract-migration.ts
+++ b/packages/core/src/util/contract-migration.ts
@@ -1,0 +1,43 @@
+import { readdirSync, readFileSync } from 'node:fs'
+import path from 'node:path'
+import type { Hash } from '@ckb-lumos/base'
+
+export type ContractMigration = {
+  cell_recipes: Array<{
+    name: string
+    tx_hash: Hash
+    index: number
+    occupied_capacity?: number
+    data_hash: Hash
+    type_id: Hash
+  }>
+}
+
+export function generateMigrationFileName() {
+  const current = new Date()
+  // YYYY-MM-DD-HHmmss.json
+  return `${current.getFullYear()}-${current.getMonth().toString().padStart(2, '0')}-${current
+    .getDay()
+    .toString()
+    .padStart(2, '0')}-${current.getHours().toString().padStart(2, '0')}${current
+    .getMinutes()
+    .toString()
+    .padStart(2, '0')}${current.getSeconds().toString().padStart(2, '0')}.json`
+}
+
+export function findMigrationByDir(dir: string, name: string) {
+  const files = readdirSync(dir)
+  const migrations = files.filter((file) => file.endsWith('.json'))
+
+  for (const migrationFileName of migrations) {
+    try {
+      const migration: ContractMigration = JSON.parse(readFileSync(path.join(dir, migrationFileName), 'utf-8'))
+      const cell = migration.cell_recipes.find((cell) => cell.name === name)
+      if (cell) {
+        return cell
+      }
+    } catch {
+      // do nothing
+    }
+  }
+}


### PR DESCRIPTION
```bash
Usage: kuai contract upgrade [options]

Options:
  --name [string]            name of the contract to be deployed (default: "")
  --bin-path [path]          path of contract bin file (default: "")
  --migration-path <string>  path of migration file
  --feepayer <string...>     address or multisig config of the transaction fee payer
                             (default: "")
  --deployer <string...>     address or multisig config of the contract deployer
                             (default: "")
  --signer [string]          signer provider [default: ckb-cli] [possible values:
                             ckb-cli, ckb-cli-multisig] (default: "")
  --fee-rate [number]        per transaction's fee, deployment may involve more than
                             one transaction. default: [1000] shannons/Byte
                             (default: 1000)
  --export [path]            export transaction to file (default: "")
  --send                     send transaction directly (default: false)
```