### PR TITLE
ci: add an action to update versions and changelogs

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -1,0 +1,70 @@
+name: Update versions and changelogs
+
+on:
+  create:
+    branches:
+      - rc/*
+
+jobs:
+  default:
+    name: Update versions and changelogs
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write # for opening PR
+      contents: write # for commit
+    env:
+      IS_RC_RBANCH: ${{ startsWith(github.ref_name, 'rc/v') }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: '0'
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18.x
+
+        # this is a patch for incompatibility between lerna@7 and npm@9 https://github.com/lerna/lerna/issues/3418#issuecomment-1337756237
+      - name: Remove lock file
+        if: env.IS_RC_RBANCH == 'true'
+        run: rm package-lock.json
+
+      - name: Get version number
+        if: env.IS_RC_RBANCH == 'true'
+        id: version-number
+        run: |
+          branch_name=${{ github.ref_name }}
+
+          version_number=${branch_name#rc/v}
+          echo "version_number=${version_number}" >> $GITHUB_OUTPUT
+
+      - name: Update versions and changelogs
+        if: env.IS_RC_RBANCH == 'true'
+        id: changelog
+        run: |
+          npm run bump-version ${{ steps.version-number.outputs.version_number }}
+
+          git add CHANGELOG.md
+          changelog=$(git diff HEAD CHANGELOG.md | tail -n +7 | cut -d"+" -f2-)
+          echo -e "changelog<<EOF"$'\n'"$changelog"$'\n'EOF >> $GITHUB_OUTPUT
+
+      - name: Set GPG
+        if: env.IS_RC_RBANCH == 'true'
+        uses: crazy-max/ghaction-import-gpg@v5
+        with:
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.GPG_PASSPHRASE }}
+          git_user_signingkey: true
+          git_commit_gpgsign: true
+
+      - name: Open PR to rc branch
+        if: env.IS_RC_RBANCH == 'true'
+        uses: peter-evans/create-pull-request@v5
+        with:
+          title: Update versions and changelogs for ${{ steps.version-number.outputs.version_number }}
+          commit-message: 'chore: update versions and changelogs'
+          body: ${{ steps.changelog.outputs.changelog }}
+          committer: Chen Yu <chenyu@magickbase.com>
+          branch: chore-update-version-for-${{ github.ref_name }}
+          add-paths: ':!package-lock.json'

--- a/lerna.json
+++ b/lerna.json
@@ -3,6 +3,7 @@
   "version": "0.0.1",
   "command": {
     "version": {
+      "message": "chore: update versions and changelogs",
       "conventionalCommits": true,
       "exact": true
     }

--- a/package.json
+++ b/package.json
@@ -19,7 +19,9 @@
     "lint": "eslint 'packages/*/{src,__tests__}/**/*.ts'",
     "prepare": "husky install",
     "format:check": "prettier -cu packages/**/src/*",
-    "format:write": "prettier -wu packages/**/src/*"
+    "format:write": "prettier -wu packages/**/src/*",
+    "bump-version": "npx lerna version --no-git-tag-version --no-private --no-push --sign-git-commit --yes",
+    "publish": "npx lerna publish --no-private"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "6.1.0",

--- a/packages/samples/mvp-dapp/package.json
+++ b/packages/samples/mvp-dapp/package.json
@@ -1,5 +1,6 @@
 {
   "name": "kuai-mvp-dapp",
+  "private": true,
   "scripts": {
     "dev": "ts-node src/main.ts",
     "build": "tsc",

--- a/packages/typeorm/package.json
+++ b/packages/typeorm/package.json
@@ -4,6 +4,7 @@
   "description": "Inject TypeOrm by InversifyJs",
   "author": "felicityin <yinjingping2022@gmail.com>",
   "homepage": "https://github.com/ckb-js/kuai#readme",
+  "private": true,
   "license": "MIT",
   "main": "lib/index.js",
   "directories": {


### PR DESCRIPTION
This PR adds an action to update versions and changelogs

The action is triggered by branch name pattern `rc/v*`, e.g. `rc/v0.1.0`, and
1. bump versions by the version number matched in branch name pattern;
2. generate changelogs by lerna;
3. open a PR to the `rc/v*` branch for reviewing the changelog

Notice that
```bash
secrets.GPG_PRIVATE_KEY
secrets.GPG_PASSPHRASE
```
are required in the action to sign commits