### PR TITLE
ci: add an action to publish pacakges to npm registry on release

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -1,0 +1,38 @@
+name: Publish packages to npm registry
+on:
+  release:
+    types:
+      - published
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Set registry
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          registry-url: https://registry.npmjs.org
+
+      - name: restore lerna
+        uses: actions/cache@v3
+        with:
+          path: '**/node_modules'
+          key: ${{ runner.os }}-${{ hashFiles('**/package-lock.json') }}
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build packages
+        run: npm run build
+
+      - name: Run test
+        run: npx lerna run test
+
+      - name: Publish
+        run: npm run publish:all
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "lint": "eslint 'packages/*/{src,__tests__}/**/*.ts'",
     "prepare": "husky install",
     "format:check": "prettier -cu packages/**/src/*",
-    "format:write": "prettier -wu packages/**/src/*"
+    "format:write": "prettier -wu packages/**/src/*",
+    "publish:all": "npx lerna publish --no-private from-package --yes"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "6.1.0",


### PR DESCRIPTION
This PR adds an action to publish npm packages when a release is published