### PR TITLE
ci: update linked dependencies when versions bump

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "prepare": "husky install",
     "format:check": "prettier -cu packages/**/src/*",
     "format:write": "prettier -wu packages/**/src/*",
-    "bump-version": "npx lerna version --no-git-tag-version --no-private --no-push --sign-git-commit --yes",
+    "bump-version": "npx lerna version --no-git-tag-version --no-push --sign-git-commit --yes",
     "publish:all": "npx lerna publish --no-private from-package --yes"
   },
   "devDependencies": {

--- a/packages/samples/mvp-dapp/package.json
+++ b/packages/samples/mvp-dapp/package.json
@@ -1,6 +1,7 @@
 {
   "name": "kuai-mvp-dapp",
   "private": true,
+  "version": "0.0.1-alpha",
   "scripts": {
     "dev": "ts-node src/main.ts",
     "build": "tsc",


### PR DESCRIPTION
Remove --no-private option in bump-version script to update dependencies in the private packages

Ref: https://github.com/ckb-js/kuai/issues/388