### PR TITLE
fix: strip ansi colors code from output for matching

### DIFF
--- a/packages/cli/__tests__/index.ts
+++ b/packages/cli/__tests__/index.ts
@@ -286,8 +286,10 @@ describe('kuai cli', () => {
     })
 
     test('pass multiple variadic param', () => {
+      /* eslint-disable-next-line no-control-regex */
+      const ANSI_COLORS_CODE_REG = /\u001b\[[0-9;]*m/g
       const output = execSync(`npx kuai --config ${CONFIG_PATH} variadic-task --variadicParam 1 2`)
-      expect(output.toString()).toMatch('{ variadicParam: [ 1, 2 ] }')
+      expect(output.toString().replace(ANSI_COLORS_CODE_REG, '')).toMatch('{ variadicParam: [ 1, 2 ] }')
     })
   })
 })


### PR DESCRIPTION
This PR fixes test case by striping ANSI COLORS CODE from the output of commands.

![image](https://github.com/ckb-js/kuai/assets/7271329/b976014f-f378-4d81-9d56-5f8448e1f96b)

Notice the numbers in `received string` are colored `yellow`

Ref:
- Ansi codes: https://gist.github.com/fnky/458719343aabd01cfb17a3a4f7296797
- Error in CI: https://github.com/ckb-js/kuai/pull/394#issuecomment-1652842934