### PR TITLE
fix: use railway env name

### DIFF
--- a/packages/samples/mvp-dapp/kuai.config.js
+++ b/packages/samples/mvp-dapp/kuai.config.js
@@ -15,13 +15,27 @@ if (process.env.REDIS_OPT) {
   }
 }
 
+// fallback to REDISUSER due to https://github.com/ckb-js/kuai/pull/423#issuecomment-1668983983
+const REDIS_USER = redisOpt?.username ?? process.env.REDUSUSER
+const REDIS_PASSWORD = redisOpt?.password ?? process.env.REDISPASSWORD
+const REDIS_HOST = process.env.REDIS_HOST ?? process.env.REDISHOST
+const REDIS_PORT = process.env.REDIS_PORT ?? process.env.REDISPORT
+
+const redisAuth = REDIS_USER && REDIS_PASSWORD ? { username: REDIS_USER, password: REDIS_PASSWORD } : undefined
+
 module.exports = {
   host: process.env.HOST,
   port: process.env.PORT,
   network: 'testnet',
-  redisPort: process.env.REDIS_PORT,
-  redisHost: process.env.REDIS_HOST,
-  redisOpt,
+  redisPort: REDIS_PORT,
+  redisHost: REDIS_HOST,
+  redisOpt:
+    redisOpt || redisAuth
+      ? {
+          ...redisOpt,
+          ...redisAuth,
+        }
+      : undefined,
   jest: {
     preset: 'ts-jest',
     testEnvironment: 'node',


### PR DESCRIPTION
Cause of using `REDIS_` env name will not run success with the `railway`. So I change the env name to the `railway`'s default env name.