### PR TITLE
Revert "chore(deps): update codecov/codecov-action action to v4"

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -26,4 +26,4 @@ jobs:
         run: npx lerna run test -- --coverage
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v3


### PR DESCRIPTION
Reverts ckb-js/kuai#484 because it cannot be resolved, maybe because it's a pre-release